### PR TITLE
update nix rust-toolchain, llvm devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739932111,
-        "narHash": "sha256-WkayjH0vuGw0hx2gmjTUGFRvMKpM17gKcpL/U8EUUw0=",
+        "lastModified": 1740191166,
+        "narHash": "sha256-WqRxO1Afx8jPYG4CKwkvDFWFvDLCwCd4mxb97hFGYPg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "75b2271c5c087d830684cd5462d4410219acc367",
+        "rev": "74a3fb71b0cc67376ab9e7c31abcd68c813fc226",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
           ];
           craneDevShell = craneLib.devShell.override {
             mkShell = pkgs.mkShell.override {
-              stdenv = builtins.foldl' (acc: adapter: adapter acc) stdenv adapters;
+              stdenv = builtins.foldl' (acc: adapter: adapter acc) pkgs.llvmPackages_latest.stdenv adapters;
             };
           };
         in


### PR DESCRIPTION
updated `inputs.rust-overlay` to sync with latest rust stable release on 2025-02-20
experiment with using LLVM in the devShell