### PR TITLE
(quick) fix: icons `next` / `back`

### DIFF
--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -283,7 +283,9 @@ impl Render for PlaybackSection {
                             .on_click(|_, window, cx| {
                                 window.dispatch_action(Box::new(Previous), cx);
                             })
-                            .child(""),
+                            // icon: `backward-step`
+                            // https://fontawesome.com/icons/backward-step?f=classic&s=solid
+                            .child("\u{f048}"),
                     )
                     .child(
                         div()
@@ -330,7 +332,9 @@ impl Render for PlaybackSection {
                             .on_click(|_, window, cx| {
                                 window.dispatch_action(Box::new(Next), cx);
                             })
-                            .child(""),
+                            // icon: `forward-step`
+                            // https://fontawesome.com/icons/forward-step?f=classic&s=solid
+                            .child("\u{f051}"),
                     ),
             )
     }


### PR DESCRIPTION
Current icons for `next` or `back` buttons are more `forward` (`ff`) and `rewind` (`rew`) symbols. Anybody from the 80s might remember this :sunglasses: .

This PR just changes those symbols to be more similar to other music player out there (YT, Amazon etc.).

## Before

![current-control](https://github.com/user-attachments/assets/aabe88e4-3f20-40c0-b699-d3972a242ca8)


## Fix

![fix-control](https://github.com/user-attachments/assets/8075bf11-80fa-41cc-bdd0-52ec5f91b941)
