### PR TITLE
feat(storage): persist app settings into `app_data.json`

### DIFF
--- a/src/playback/interface.rs
+++ b/src/playback/interface.rs
@@ -68,7 +68,6 @@ impl GPUIPlaybackInterface {
             .expect("could not send tx");
     }
 
-
     pub fn open(&self, path: PathBuf) {
         self.commands_tx
             .send(PlaybackCommand::Open(path))

--- a/src/playback/thread.rs
+++ b/src/playback/thread.rs
@@ -510,7 +510,7 @@ impl PlaybackThread {
 
         if self.state == PlaybackState::Stopped {
             let path = item.get_path();
-            self.open(&path);
+            self.open(path);
             self.queue_next = pre_len + 1;
             self.events_tx
                 .send(PlaybackEvent::QueuePositionChanged(pre_len))

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,7 +13,6 @@ use tracing::{info, warn};
 pub struct Settings {
     #[serde(default)]
     pub scanning: scan::ScanSettings,
-    pub storage_data: StorageData,
 }
 
 pub fn create_settings(path: &PathBuf) -> Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,16 +1,19 @@
 pub mod scan;
+pub mod storage;
 
 use std::{fs::File, path::PathBuf, sync::mpsc::channel, time::Duration};
 
 use gpui::{App, AppContext, AsyncApp, Entity, Global};
 use notify::{Event, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
+use storage::StorageData;
 use tracing::{info, warn};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Settings {
     #[serde(default)]
     pub scanning: scan::ScanSettings,
+    pub storage_data: StorageData,
 }
 
 pub fn create_settings(path: &PathBuf) -> Settings {

--- a/src/settings/storage.rs
+++ b/src/settings/storage.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ui::models::CurrentTrack;
+
+use std::{fs, path::PathBuf};
+
+/// Data to store while quitting the app
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StorageData {
+    pub current_track: Option<CurrentTrack>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Storage {
+    /// File path to store data
+    path: PathBuf,
+}
+
+impl Storage {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Save `StorageData` on file system
+    pub fn save(&self, data: &StorageData) {
+        // save into file
+        let result = fs::File::create(self.path.clone())
+            .and_then(|file| serde_json::to_writer(file, &data).map_err(|e| e.into()));
+        // ignore error, but log it
+        if let Err(e) = result {
+            tracing::warn!("could not save `AppState` {:?}", e);
+        };
+    }
+
+    /// Load `StorageData` from storage or use `StorageData::default` in case of any errors
+    pub fn load_or_default(&self) -> StorageData {
+        std::fs::File::open(self.path.clone())
+            .and_then(|file| {
+                serde_json::from_reader(file)
+                    .map_err(|e| e.into())
+                    .map(|data: StorageData| match &data.current_track {
+                        // validate whether path still exists
+                        Some(current_track) if !current_track.get_path().exists() => StorageData {
+                            current_track: None,
+                        },
+                        _ => data,
+                    })
+            })
+            .unwrap_or_default()
+    }
+}

--- a/src/ui/library/release_view.rs
+++ b/src/ui/library/release_view.rs
@@ -154,7 +154,7 @@ impl Render for ReleaseView {
             .current_track
             .read(cx)
             .clone()
-            .map_or(false, |current_track| {
+            .is_some_and(|current_track| {
                 self.tracks
                     .iter()
                     .any(|track| current_track == track.location)


### PR DESCRIPTION
As a first step store `current_track` to restore it by re-starting the app. Ather options (e.g. volume, position, selected album id, view state etc.) can be follow.