### PR TITLE
(fix): No such device or address (Nix/Linux build only)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1739936662,
-        "narHash": "sha256-x4syUjNUuRblR07nDPeLDP7DpphaBVbUaSoeZkFbGSk=",
+        "lastModified": 1745454774,
+        "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "19de14aaeb869287647d9461cbd389187d8ecdb7",
+        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739866667,
-        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "lastModified": 1745526057,
+        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
         "type": "github"
       },
       "original": {
@@ -51,14 +51,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1738452942,
-        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {
@@ -76,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740191166,
-        "narHash": "sha256-WqRxO1Afx8jPYG4CKwkvDFWFvDLCwCd4mxb97hFGYPg=",
+        "lastModified": 1745721366,
+        "narHash": "sha256-dm93104HXjKWzkrr7yAPtxpbllOSzrwFFruc+rKQHSg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "74a3fb71b0cc67376ab9e7c31abcd68c813fc226",
+        "rev": "621131c9e281d1047bf8937547ed77e97c464aba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,9 +38,9 @@
             pkgs.openssl
             (lib.optionals stdenv.hostPlatform.isLinux [
               pkgs.alsa-lib
-              pkgs.libpulseaudio
               pkgs.libxkbcommon
               pkgs.xorg.libxcb
+              pkgs.pipewire
             ])
             (lib.optionals stdenv.hostPlatform.isDarwin [
               pkgs.apple-sdk_15
@@ -100,6 +100,7 @@
                 pkgs.wayland
               ]
             );
+            ALSA_PLUGIN_DIR = lib.optionalString stdenv.hostPlatform.isLinux "${pkgs.pipewire}/lib/alsa-lib/";
             shellHook = ''
               rustc -Vv
             '';


### PR DESCRIPTION
After removing support of `pulseaudio` in c000a33 , the app panics by trying to play a song. That's because native sound libs are missing now. It happens by building/running the app on `Linux` + `Nix` (`flake`) only.

Error message:

```sh
cargo run 

[...]

ALSA lib dlmisc.c:339:(snd_dlobj_cache_get0) Cannot open shared library libasound_module_pcm_pipewire.so (/nix/store/2bp6s10j3b6rwqn6p0wy27q78db7ldz1-alsa-lib-1.2.13/lib/alsa-lib/libasound_module_pcm_pipewire.so: cannot open shared object file: No such file or directory)

thread 'playback' panicked at src/playback/thread.rs:790:18:
failed to get device format: Unknown("A backend-specific error has occurred: ALSA function 'snd_pcm_open' failed with error 'No such device or address (6)'")

[...]

```

## Fix 

This PR adds `pipewire` explicitly as dependency and make it work with ALSA.

**No errors, no panics anymore.**

```sh
cargo run 

[...]

2025-04-27T12:52:17.572995Z  INFO muzak::playback::thread: Opened device: Ok("default"), format: Float32, rate: 44100, channel_count: 2

[...]
```