### PR TITLE
feat(scan): implement de-duplication strategy

### DIFF
--- a/migrations/20250512231103_add_album_path_track_info.sql
+++ b/migrations/20250512231103_add_album_path_track_info.sql
@@ -1,0 +1,20 @@
+ALTER TABLE album ADD folder TEXT;
+
+CREATE TRIGGER IF NOT EXISTS delete_album_path_trigger AFTER DELETE ON track BEGIN
+DELETE FROM album_path
+WHERE
+    album_path.path = OLD.folder
+    AND album_path.disc_num = OLD.disc_number
+    AND album_path.album_id = OLD.album_id
+    AND NOT EXISTS (
+        SELECT
+            1
+        FROM
+            track
+        WHERE
+            track.folder = OLD.folder
+            AND track.disc_number = OLD.disc_number
+            AND track.album_id = OLD.album_id
+    );
+
+END;

--- a/migrations/20250512231103_add_album_path_track_info.sql
+++ b/migrations/20250512231103_add_album_path_track_info.sql
@@ -1,10 +1,10 @@
-ALTER TABLE album ADD folder TEXT;
+ALTER TABLE track ADD folder TEXT;
 
 CREATE TRIGGER IF NOT EXISTS delete_album_path_trigger AFTER DELETE ON track BEGIN
 DELETE FROM album_path
 WHERE
     album_path.path = OLD.folder
-    AND album_path.disc_num = OLD.disc_number
+    AND album_path.disc_num = IFNULL (OLD.disc_number, -1)
     AND album_path.album_id = OLD.album_id
     AND NOT EXISTS (
         SELECT

--- a/queries/scan/create_album.sql
+++ b/queries/scan/create_album.sql
@@ -1,4 +1,4 @@
-INSERT INTO album (title, title_sortable, artist_id, image, thumb, release_date, label, catalog_number, isrc)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+INSERT INTO album (title, title_sortable, artist_id, image, thumb, release_date, label, catalog_number, isrc, mbid)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
     ON CONFLICT (title, artist_id, mbid) DO NOTHING -- TODO: ideally we should have some way of updating this
     RETURNING id;

--- a/queries/scan/create_album_path.sql
+++ b/queries/scan/create_album_path.sql
@@ -1,0 +1,3 @@
+INSERT INTO album_path (album_id, path, disc_num)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (album_id, disc_num) DO NOTHING;

--- a/queries/scan/create_track.sql
+++ b/queries/scan/create_track.sql
@@ -1,5 +1,5 @@
-INSERT INTO track (title, title_sortable, album_id, track_number, disc_number, duration, location, genres, artist_names)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+INSERT INTO track (title, title_sortable, album_id, track_number, disc_number, duration, location, genres, artist_names, folder)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
     ON CONFLICT (location) DO UPDATE SET
         title = EXCLUDED.title,
         title_sortable = EXCLUDED.title_sortable,
@@ -9,5 +9,6 @@ INSERT INTO track (title, title_sortable, album_id, track_number, disc_number, d
         duration = EXCLUDED.duration,
         location = EXCLUDED.location,
         genres = EXCLUDED.genres,
-        artist_names = EXCLUDED.artist_names
+        artist_names = EXCLUDED.artist_names,
+        folder = EXCLUDED.folder
     RETURNING id;

--- a/queries/scan/get_album_id.sql
+++ b/queries/scan/get_album_id.sql
@@ -1,1 +1,1 @@
-SELECT id FROM album WHERE title = $1;
+SELECT id FROM album WHERE title = $1 AND mbid = $2;

--- a/queries/scan/get_album_path.sql
+++ b/queries/scan/get_album_path.sql
@@ -1,1 +1,1 @@
- SELECT path FROM album_path WHERE album_id = $1 AND disc_num = $2;
+SELECT path FROM album_path WHERE album_id = $1 AND disc_num = $2;

--- a/queries/scan/get_album_path.sql
+++ b/queries/scan/get_album_path.sql
@@ -1,0 +1,1 @@
+ SELECT path FROM album_path WHERE album_id = $1 AND disc_num = $2;

--- a/src/library/scan.rs
+++ b/src/library/scan.rs
@@ -402,9 +402,16 @@ impl ScanThread {
         let Some(album) = &metadata.album else {
             return Ok(None);
         };
+
+        let mbid = metadata
+            .mbid_album
+            .clone()
+            .unwrap_or_else(|| "none".to_string());
+
         let result: Result<(i64,), sqlx::Error> =
             sqlx::query_as(include_str!("../../queries/scan/get_album_id.sql"))
                 .bind(album)
+                .bind(&mbid)
                 .fetch_one(&self.pool)
                 .await;
 
@@ -475,6 +482,7 @@ impl ScanThread {
                         .bind(&metadata.label)
                         .bind(&metadata.catalog)
                         .bind(&metadata.isrc)
+                        .bind(&mbid)
                         .fetch_one(&self.pool)
                         .await?;
 

--- a/src/media/builtin/symphonia.rs
+++ b/src/media/builtin/symphonia.rs
@@ -132,6 +132,9 @@ impl SymphoniaProvider {
                 Some(StandardTagKey::SortAlbumArtist) => {
                     self.current_metadata.artist_sort = Some(tag.value.to_string())
                 }
+                Some(StandardTagKey::MusicBrainzAlbumId) => {
+                    self.current_metadata.mbid_album = Some(tag.value.to_string())
+                }
                 _ => (),
             }
         }

--- a/src/media/metadata.rs
+++ b/src/media/metadata.rs
@@ -24,4 +24,6 @@ pub struct Metadata {
     pub label: Option<String>,
     pub catalog: Option<String>,
     pub isrc: Option<String>,
+
+    pub mbid_album: Option<String>,
 }


### PR DESCRIPTION
The scanner will now use the MusicBrainz ID of an album to determine if that album is a duplicate, as well as the previously used title and album ID. This will allow multiple versions of the same album to be properly represented, assuming that all versions are properly tagged.

In addition, disc numbers are now associated to parent folders, meaning that the scanner should no longer take multiple copies of the same album and associate them with one album, which created one album with multiple copies of the same track.

Combined, these two strategies should cut down on the most common scanning issues significantly. In order to take advantage of this going forward, the database should be deleted and rescanned.