### PR TITLE
feat: open error handling in src/playback/threads.rs

### DIFF
--- a/src/devices/builtin/cpal.rs
+++ b/src/devices/builtin/cpal.rs
@@ -8,16 +8,16 @@ use crate::{
         },
         format::{BufferSize, ChannelSpec, FormatInfo, SampleFormat, SupportedFormat},
         traits::{Device, DeviceProvider, OutputStream},
-        util::{interleave, Scale},
+        util::{Scale, interleave},
     },
     media::playback::{GetInnerSamples, Mute, PlaybackFrame},
     util::make_unknown_error,
 };
 use cpal::{
-    traits::{DeviceTrait, HostTrait, StreamTrait},
     Host, SizedSample,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
 };
-use rb::{Producer, RbConsumer, RbProducer, SpscRb, RB};
+use rb::{Producer, RB, RbConsumer, RbProducer, SpscRb};
 
 pub struct CpalProvider {
     host: Host,

--- a/src/devices/builtin/win_audiograph.rs
+++ b/src/devices/builtin/win_audiograph.rs
@@ -1,9 +1,8 @@
 use std::slice::from_raw_parts_mut;
 
-use rb::{Producer, RbConsumer, RbProducer, SpscRb, RB};
+use rb::{Producer, RB, RbConsumer, RbProducer, SpscRb};
 use tracing::error;
 use windows::{
-    core::Interface,
     Devices::Enumeration::{DeviceClass, DeviceInformation},
     Foundation::TypedEventHandler,
     Media::{
@@ -15,6 +14,7 @@ use windows::{
         Render::AudioRenderCategory,
     },
     Win32::System::WinRT::IMemoryBufferByteAccess,
+    core::Interface,
 };
 
 use crate::{
@@ -25,7 +25,7 @@ use crate::{
         },
         format::{BufferSize, ChannelSpec, FormatInfo, SampleFormat, SupportedFormat},
         traits::{Device, DeviceProvider, OutputStream},
-        util::{interleave, Packed},
+        util::{Packed, interleave},
     },
     media::playback::{GetInnerSamples, PlaybackFrame},
     util::make_unknown_error,

--- a/src/library/types.rs
+++ b/src/library/types.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use gpui::{IntoElement, RenderImage, SharedString};
 use image::{Frame, RgbaImage};
 use smallvec::SmallVec;
-use sqlx::{encode::IsNull, error::BoxDynError, Database, Decode, Sqlite, Type};
+use sqlx::{Database, Decode, Sqlite, Type, encode::IsNull, error::BoxDynError};
 
 use crate::util::rgb_to_bgr;
 

--- a/src/media/builtin/symphonia.rs
+++ b/src/media/builtin/symphonia.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use symphonia::{
     core::{
         audio::{AudioBufferRef, Channels, Signal},
-        codecs::{Decoder, DecoderOptions, CODEC_TYPE_NULL},
+        codecs::{CODEC_TYPE_NULL, Decoder, DecoderOptions},
         errors::Error,
         formats::{FormatOptions, FormatReader, SeekMode, SeekTo},
         io::MediaSourceStream,

--- a/src/media/errors.rs
+++ b/src/media/errors.rs
@@ -30,6 +30,12 @@ pub enum PlaybackStartError {
     BrokenContainer,
     #[error("Container is supported but not codec")]
     ContainerSupportedButNotCodec,
+    #[error("Failed to process media: {0}")]
+    MediaError(String),
+    #[error("Audio stream error: {0}")]
+    StreamError(String),
+    #[error("Channel configuration error: {0}")]
+    ChannelError(String),
     #[error("Unknown media provider error: `{0}`")]
     Unknown(String),
 }

--- a/src/services/controllers.rs
+++ b/src/services/controllers.rs
@@ -83,7 +83,7 @@ pub trait PlaybackController {
     /// Indicates that the playback state has changed. When the PlaybackState is Stopped, no file
     /// is queued for playback.
     async fn playback_state_changed(&mut self, playback_state: PlaybackState)
-        -> anyhow::Result<()>;
+    -> anyhow::Result<()>;
 
     /// Indicates that the shuffle state has changed.
     async fn shuffle_state_changed(&mut self, shuffling: bool) -> anyhow::Result<()>;

--- a/src/services/controllers/macos.rs
+++ b/src/services/controllers/macos.rs
@@ -3,7 +3,7 @@ use std::{path::Path, ptr::NonNull, sync::Arc};
 use async_lock::Mutex;
 use async_trait::async_trait;
 use block2::RcBlock;
-use objc2::{rc::Retained, runtime::ProtocolObject, AnyThread};
+use objc2::{AnyThread, rc::Retained, runtime::ProtocolObject};
 use objc2_app_kit::NSImage;
 use objc2_core_foundation::CGSize;
 use objc2_foundation::{NSData, NSMutableDictionary, NSNumber, NSString};

--- a/src/services/controllers/mpris.rs
+++ b/src/services/controllers/mpris.rs
@@ -5,7 +5,7 @@ use std::{
 
 use async_lock::{Mutex, RwLock};
 use async_trait::async_trait;
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 use mpris_server::{
     LoopStatus, PlaybackRate, PlaybackStatus, PlayerInterface, Property, RootInterface, Server,
     Signal, Time, Volume,

--- a/src/services/controllers/windows.rs
+++ b/src/services/controllers/windows.rs
@@ -4,7 +4,6 @@ use async_lock::Mutex;
 use async_trait::async_trait;
 use raw_window_handle::RawWindowHandle;
 use windows::{
-    core::HSTRING,
     Foundation::TypedEventHandler,
     Media::{
         MediaPlaybackAutoRepeatMode, MediaPlaybackStatus, MediaPlaybackType,
@@ -14,6 +13,7 @@ use windows::{
     },
     Storage::Streams::{DataWriter, InMemoryRandomAccessStream, RandomAccessStreamReference},
     Win32::{Foundation::HWND, System::WinRT::ISystemMediaTransportControlsInterop},
+    core::HSTRING,
 };
 
 use crate::{

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -63,41 +63,43 @@ pub fn setup_settings(cx: &mut App, path: PathBuf) {
         warn!("failed to watch settings file: {:?}", e);
     }
 
-    cx.spawn(async move |app: &mut AsyncApp| loop {
-        while let Ok(event) = rx.try_recv() {
-            match event {
-                Ok(v) => {
-                    if !v.paths.iter().any(|t| t.ends_with("settings.json")) {
-                        return;
-                    };
-                    match v.kind {
-                        notify::EventKind::Create(_) | notify::EventKind::Modify(_) => {
-                            info!("Settings changed, updating...");
-                            let settings = create_settings(&path);
-                            settings_model
-                                .update(app, |v, _| {
-                                    *v = settings;
-                                })
-                                .expect("settings model could not be updated");
+    cx.spawn(async move |app: &mut AsyncApp| {
+        loop {
+            while let Ok(event) = rx.try_recv() {
+                match event {
+                    Ok(v) => {
+                        if !v.paths.iter().any(|t| t.ends_with("settings.json")) {
+                            return;
+                        };
+                        match v.kind {
+                            notify::EventKind::Create(_) | notify::EventKind::Modify(_) => {
+                                info!("Settings changed, updating...");
+                                let settings = create_settings(&path);
+                                settings_model
+                                    .update(app, |v, _| {
+                                        *v = settings;
+                                    })
+                                    .expect("settings model could not be updated");
+                            }
+                            notify::EventKind::Remove(_) => {
+                                info!("Settings file removed, using default settings");
+                                settings_model
+                                    .update(app, |v, _| {
+                                        *v = Settings::default();
+                                    })
+                                    .expect("settings model could not be updated");
+                            }
+                            _ => (),
                         }
-                        notify::EventKind::Remove(_) => {
-                            info!("Settings file removed, using default settings");
-                            settings_model
-                                .update(app, |v, _| {
-                                    *v = Settings::default();
-                                })
-                                .expect("settings model could not be updated");
-                        }
-                        _ => (),
                     }
+                    Err(e) => warn!("watch error: {:?}", e),
                 }
-                Err(e) => warn!("watch error: {:?}", e),
             }
-        }
 
-        app.background_executor()
-            .timer(Duration::from_millis(10))
-            .await;
+            app.background_executor()
+                .timer(Duration::from_millis(10))
+                .await;
+        }
     })
     .detach();
 

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -1,10 +1,10 @@
 use gpui::{
-    div, img, px, FontWeight, InteractiveElement, IntoElement, ParentElement, RenderOnce,
-    StatefulInteractiveElement, Styled,
+    FontWeight, InteractiveElement, IntoElement, ParentElement, RenderOnce,
+    StatefulInteractiveElement, Styled, div, img, px,
 };
 
 use super::{
-    components::modal::{modal, OnExitHandler},
+    components::modal::{OnExitHandler, modal},
     theme::Theme,
 };
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -18,9 +18,8 @@ use crate::{
     playback::{interface::GPUIPlaybackInterface, queue::QueueItemData, thread::PlaybackThread},
     services::controllers::make_cl,
     settings::{
-        setup_settings,
+        SettingsGlobal, setup_settings,
         storage::{Storage, StorageData},
-        SettingsGlobal,
     },
     ui::{assets::HummingbirdAssetSource, constants::APP_SHADOW_SIZE},
 };
@@ -35,10 +34,10 @@ use super::{
     global_actions::register_actions,
     header::Header,
     library::Library,
-    models::{self, build_models, Models, PlaybackInfo},
+    models::{self, Models, PlaybackInfo, build_models},
     queue::Queue,
     search::SearchView,
-    theme::{setup_theme, Theme},
+    theme::{Theme, setup_theme},
     util::drop_image_from_app,
 };
 

--- a/src/ui/caching.rs
+++ b/src/ui/caching.rs
@@ -3,8 +3,8 @@ use std::{collections::VecDeque, mem::take};
 use ahash::HashMapExt;
 use futures::FutureExt;
 use gpui::{
-    hash, App, AppContext, Asset, AssetLogger, ElementId, Entity, ImageAssetLoader, ImageCache,
-    ImageCacheItem, ImageCacheProvider, ImageSource, Resource,
+    App, AppContext, Asset, AssetLogger, ElementId, Entity, ImageAssetLoader, ImageCache,
+    ImageCacheItem, ImageCacheProvider, ImageSource, Resource, hash,
 };
 use rustc_hash::FxHashMap;
 use tracing::{debug, error};

--- a/src/ui/components/icons/icon.rs
+++ b/src/ui/components/icons/icon.rs
@@ -1,4 +1,4 @@
-use gpui::{svg, IntoElement, RenderOnce, SharedString, StyleRefinement, Styled, Svg};
+use gpui::{IntoElement, RenderOnce, SharedString, StyleRefinement, Styled, Svg, svg};
 
 use crate::ui::theme::Theme;
 

--- a/src/ui/components/nav_button.rs
+++ b/src/ui/components/nav_button.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    div, px, Div, ElementId, InteractiveElement, IntoElement, ParentElement, RenderOnce, Stateful,
-    StatefulInteractiveElement, StyleRefinement, Styled,
+    Div, ElementId, InteractiveElement, IntoElement, ParentElement, RenderOnce, Stateful,
+    StatefulInteractiveElement, StyleRefinement, Styled, div, px,
 };
 
 use crate::ui::{components::icons::icon, theme::Theme};

--- a/src/ui/components/sidebar.rs
+++ b/src/ui/components/sidebar.rs
@@ -1,7 +1,7 @@
 use gpui::{
-    div, prelude::FluentBuilder, px, App, Div, ElementId, FontWeight, InteractiveElement,
-    IntoElement, ParentElement, RenderOnce, Stateful, StatefulInteractiveElement, StyleRefinement,
-    Styled, Window,
+    App, Div, ElementId, FontWeight, InteractiveElement, IntoElement, ParentElement, RenderOnce,
+    Stateful, StatefulInteractiveElement, StyleRefinement, Styled, Window, div,
+    prelude::FluentBuilder, px,
 };
 
 use crate::ui::{components::icons::icon, theme::Theme, util::MaybeStateful};

--- a/src/ui/components/table.rs
+++ b/src/ui/components/table.rs
@@ -12,7 +12,7 @@ use table_item::TableItem;
 
 use crate::ui::{
     caching::hummingbird_cache,
-    components::icons::{icon, CHEVRON_DOWN, CHEVRON_UP},
+    components::icons::{CHEVRON_DOWN, CHEVRON_UP, icon},
     theme::Theme,
     util::{create_or_retrieve_view, prune_views},
 };

--- a/src/ui/components/table/table_item.rs
+++ b/src/ui/components/table/table_item.rs
@@ -7,8 +7,8 @@ use rustc_hash::FxBuildHasher;
 use crate::ui::theme::Theme;
 
 use super::{
-    table_data::{Column, TableData},
     OnSelectHandler,
+    table_data::{Column, TableData},
 };
 
 #[derive(Clone)]

--- a/src/ui/data.rs
+++ b/src/ui/data.rs
@@ -3,7 +3,7 @@ use std::{fs::File, hash::Hasher, io::Cursor, sync::Arc};
 use ahash::AHasher;
 use async_lock::Mutex;
 use gpui::{App, AppContext, Entity, Global, RenderImage, SharedString, Task};
-use image::{imageops::thumbnail, Frame, ImageReader};
+use image::{Frame, ImageReader, imageops::thumbnail};
 use smallvec::smallvec;
 use tracing::{debug, error};
 

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -6,7 +6,7 @@ use prelude::FluentBuilder;
 use crate::{
     library::scan::ScanEvent,
     services::mmb::lastfm::{LASTFM_API_KEY, LASTFM_API_SECRET},
-    ui::components::icons::{icon, CROSS, FOLDER_CHECK, FOLDER_SEARCH, MAXIMIZE, MINUS},
+    ui::components::icons::{CROSS, FOLDER_CHECK, FOLDER_SEARCH, MAXIMIZE, MINUS, icon},
 };
 
 use super::{constants::APP_ROUNDING, models::Models, theme::Theme};

--- a/src/ui/header/lastfm.rs
+++ b/src/ui/header/lastfm.rs
@@ -2,9 +2,9 @@ use gpui::*;
 use tracing::error;
 
 use crate::{
-    services::mmb::lastfm::{client::LastFMClient, LASTFM_API_KEY, LASTFM_API_SECRET},
+    services::mmb::lastfm::{LASTFM_API_KEY, LASTFM_API_SECRET, client::LastFMClient},
     ui::{
-        components::icons::{icon, LAST_FM},
+        components::icons::{LAST_FM, icon},
         models::{LastFMState, Models},
         theme::Theme,
     },

--- a/src/ui/library/album_view.rs
+++ b/src/ui/library/album_view.rs
@@ -5,7 +5,7 @@ use gpui::*;
 use crate::{
     library::{
         scan::ScanEvent,
-        types::{table::AlbumColumn, Album},
+        types::{Album, table::AlbumColumn},
     },
     ui::{
         components::table::{Table, TableEvent},

--- a/src/ui/library/playlist_view.rs
+++ b/src/ui/library/playlist_view.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use ahash::AHashMap;
 use gpui::{
-    div, px, rems, uniform_list, App, AppContext, Context, Entity, FontWeight, ParentElement,
-    Render, Styled, Window,
+    App, AppContext, Context, Entity, FontWeight, ParentElement, Render, Styled, Window, div, px,
+    rems, uniform_list,
 };
 
 use crate::{
@@ -12,17 +12,17 @@ use crate::{
         types::{Playlist, PlaylistType},
     },
     playback::{
-        interface::{replace_queue, GPUIPlaybackInterface},
+        interface::{GPUIPlaybackInterface, replace_queue},
         queue::QueueItemData,
     },
     ui::{
         components::{
-            button::{button, ButtonIntent, ButtonSize},
-            icons::{icon, CIRCLE_PLUS, PLAY, PLAYLIST, SHUFFLE, STAR},
+            button::{ButtonIntent, ButtonSize, button},
+            icons::{CIRCLE_PLUS, PLAY, PLAYLIST, SHUFFLE, STAR, icon},
         },
         library::track_listing::{
-            track_item::{TrackItem, TrackItemLeftField},
             ArtistNameVisibility,
+            track_item::{TrackItem, TrackItemLeftField},
         },
         models::{Models, PlaybackInfo, PlaylistEvent},
         theme::Theme,

--- a/src/ui/library/sidebar/playlists.rs
+++ b/src/ui/library/sidebar/playlists.rs
@@ -1,8 +1,8 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use gpui::{
-    div, prelude::FluentBuilder, px, App, AppContext, Context, Entity, FontWeight, ParentElement,
-    Render, StatefulInteractiveElement, Styled, Window,
+    App, AppContext, Context, Entity, FontWeight, ParentElement, Render,
+    StatefulInteractiveElement, Styled, Window, div, prelude::FluentBuilder, px,
 };
 
 use crate::{

--- a/src/ui/library/track_listing/track_item.rs
+++ b/src/ui/library/track_listing/track_item.rs
@@ -1,12 +1,12 @@
 use gpui::prelude::{FluentBuilder, *};
-use gpui::{div, img, px, App, Entity, FontWeight, IntoElement, SharedString, Window};
+use gpui::{App, Entity, FontWeight, IntoElement, SharedString, Window, div, img, px};
 
-use crate::ui::components::icons::{icon, PLAY, PLUS, STAR, STAR_FILLED};
+use crate::ui::components::icons::{PLAY, PLUS, STAR, STAR_FILLED, icon};
 use crate::ui::models::PlaylistEvent;
 use crate::{
     library::{db::LibraryAccess, types::Track},
     playback::{
-        interface::{replace_queue, GPUIPlaybackInterface},
+        interface::{GPUIPlaybackInterface, replace_queue},
         queue::QueueItemData,
     },
     ui::{

--- a/src/ui/models.rs
+++ b/src/ui/models.rs
@@ -20,10 +20,10 @@ use crate::{
         thread::PlaybackState,
     },
     services::mmb::{
-        lastfm::{client::LastFMClient, types::Session, LastFM, LASTFM_API_KEY, LASTFM_API_SECRET},
         MediaMetadataBroadcastService,
+        lastfm::{LASTFM_API_KEY, LASTFM_API_SECRET, LastFM, client::LastFMClient, types::Session},
     },
-    settings::{storage::StorageData, SettingsGlobal},
+    settings::{SettingsGlobal, storage::StorageData},
     ui::{app::get_dirs, data::Decode, library::ViewSwitchMessage},
 };
 

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -4,7 +4,7 @@ use crate::{
         queue::{DataSource, QueueItemData},
     },
     ui::components::{
-        icons::{icon, CROSS, SHUFFLE, TRASH},
+        icons::{CROSS, SHUFFLE, TRASH, icon},
         nav_button::nav_button,
     },
 };
@@ -13,7 +13,7 @@ use gpui::*;
 use prelude::FluentBuilder;
 
 use super::{
-    components::button::{button, ButtonSize, ButtonStyle},
+    components::button::{ButtonSize, ButtonStyle, button},
     models::{Models, PlaybackInfo},
     theme::Theme,
     util::{create_or_retrieve_view, drop_image_from_app, prune_views},

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::BufReader, path::PathBuf, sync::mpsc::channel, time::Duration};
 
-use gpui::{rgb, rgba, App, AppContext, AsyncApp, EventEmitter, Global, Rgba};
+use gpui::{App, AppContext, AsyncApp, EventEmitter, Global, Rgba, rgb, rgba};
 use notify::{Event, RecursiveMode, Watcher};
 use serde::Deserialize;
 use tracing::{error, info, warn};
@@ -205,40 +205,42 @@ pub fn setup_theme(cx: &mut App, path: PathBuf) {
             warn!("failed to watch settings directory: {:?}", e);
         }
 
-        cx.spawn(async move |cx: &mut AsyncApp| loop {
-            while let Ok(event) = rx.try_recv() {
-                match event {
-                    Ok(v) => {
-                        if v.paths.iter().any(|t| t.ends_with("theme.json")) {
-                            match v.kind {
-                                notify::EventKind::Create(_) | notify::EventKind::Modify(_) => {
-                                    info!("Theme changed, updating...");
-                                    let theme = create_theme(&path);
-                                    theme_transmitter
-                                        .update(cx, move |_, m| {
-                                            m.emit(theme);
-                                        })
-                                        .expect("could not send theme to main thread");
+        cx.spawn(async move |cx: &mut AsyncApp| {
+            loop {
+                while let Ok(event) = rx.try_recv() {
+                    match event {
+                        Ok(v) => {
+                            if v.paths.iter().any(|t| t.ends_with("theme.json")) {
+                                match v.kind {
+                                    notify::EventKind::Create(_) | notify::EventKind::Modify(_) => {
+                                        info!("Theme changed, updating...");
+                                        let theme = create_theme(&path);
+                                        theme_transmitter
+                                            .update(cx, move |_, m| {
+                                                m.emit(theme);
+                                            })
+                                            .expect("could not send theme to main thread");
+                                    }
+                                    notify::EventKind::Remove(_) => {
+                                        info!("Theme file removed, resetting to default...");
+                                        theme_transmitter
+                                            .update(cx, |_, m| {
+                                                m.emit(Theme::default());
+                                            })
+                                            .expect("could not send theme to main thread");
+                                    }
+                                    _ => (),
                                 }
-                                notify::EventKind::Remove(_) => {
-                                    info!("Theme file removed, resetting to default...");
-                                    theme_transmitter
-                                        .update(cx, |_, m| {
-                                            m.emit(Theme::default());
-                                        })
-                                        .expect("could not send theme to main thread");
-                                }
-                                _ => (),
                             }
                         }
+                        Err(e) => error!("error occured while watching theme.json: {:?}", e),
                     }
-                    Err(e) => error!("error occured while watching theme.json: {:?}", e),
                 }
-            }
 
-            cx.background_executor()
-                .timer(Duration::from_millis(10))
-                .await;
+                cx.background_executor()
+                    .timer(Duration::from_millis(10))
+                    .await;
+            }
         })
         .detach();
 


### PR DESCRIPTION
This PR stemmed from #56.

It adds error handling to the `open` method in threads.rs. When you run the dev build with `cargo run hummingbird`, it causes panic which hangs the application.

This PR adds some error handling to this method which is helpful in fixing dev build issue, although it turns out running with `cargo run` alone wouldnt cause dev build crash. So the main point of this PR is adding some error handling and some code tidyup.