### PR TITLE
feat: remember queue state on exit

### DIFF
--- a/src/playback/queue.rs
+++ b/src/playback/queue.rs
@@ -3,7 +3,9 @@ use std::{fmt::Display, sync::Arc};
 use gpui::{App, AppContext, Entity, RenderImage, SharedString};
 use std::path::PathBuf;
 
-use crate::{library::db::LibraryAccess, ui::data::Decode};
+use crate::{
+    library::db::LibraryAccess, settings::storage::SerializableQueueItem, ui::data::Decode,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct QueueItemData {
@@ -52,6 +54,20 @@ impl QueueItemData {
             db_album_id,
             data: cx.new(|_| None),
         }
+    }
+
+    /// Convert to a serializable format for persistence
+    pub fn to_serializable(&self) -> SerializableQueueItem {
+        SerializableQueueItem {
+            path: self.path.clone(),
+            db_id: self.db_id,
+            db_album_id: self.db_album_id,
+        }
+    }
+
+    /// Create from a serializable format
+    pub fn from_serializable(cx: &mut App, item: SerializableQueueItem) -> Self {
+        Self::new(cx, item.path, item.db_id, item.db_album_id)
     }
 
     /// Returns a copy of the UI data after ensuring that the metadata is loaded (or going to be

--- a/src/ui/models.rs
+++ b/src/ui/models.rs
@@ -266,7 +266,7 @@ pub fn build_models(cx: &mut App, queue: Queue, storage_data: &StorageData) {
     let playback_state: Entity<PlaybackState> = cx.new(|_| PlaybackState::Stopped);
     let current_track: Entity<Option<CurrentTrack>> =
         cx.new(|_| storage_data.current_track.clone());
-    let shuffling: Entity<bool> = cx.new(|_| false);
+    let shuffling: Entity<bool> = cx.new(|_| storage_data.is_shuffled);
     let repeating: Entity<RepeatState> = cx.new(|cx| {
         let settings = cx.global::<SettingsGlobal>().model.read(cx);
 


### PR DESCRIPTION
this pr persists playback queue state (contents, position, and shuffle status) across application restarts.

closes #80 