### PR TITLE
feat: persist playback volume setting

### DIFF
--- a/src/playback/thread.rs
+++ b/src/playback/thread.rs
@@ -127,6 +127,7 @@ impl PlaybackThread {
     pub fn start(
         queue: Arc<RwLock<Vec<QueueItemData>>>,
         settings: PlaybackSettings,
+        last_volume: f64,
     ) -> PlaybackInterface {
         // TODO: use the refresh rate for the bounds
         let (cmd_tx, commands_rx) = unbounded_channel();
@@ -158,7 +159,7 @@ impl PlaybackThread {
                         RepeatState::NotRepeating
                     },
                     playback_settings: settings,
-                    last_volume: 1.0,
+                    last_volume,
                 };
 
                 thread.run();

--- a/src/settings/storage.rs
+++ b/src/settings/storage.rs
@@ -16,6 +16,10 @@ fn default_queue_width() -> f32 {
     f32::from(DEFAULT_QUEUE_WIDTH)
 }
 
+fn default_volume() -> f64 {
+    1.0
+}
+
 fn default_table_settings() -> HashMap<String, TableSettings> {
     HashMap::new()
 }
@@ -32,6 +36,8 @@ pub struct TableSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageData {
     pub current_track: Option<CurrentTrack>,
+    #[serde(default = "default_volume")]
+    pub volume: f64,
     /// Width of the library sidebar in pixels
     #[serde(default = "default_sidebar_width")]
     pub sidebar_width: f32,
@@ -56,6 +62,7 @@ impl Default for StorageData {
     fn default() -> Self {
         Self {
             current_track: None,
+            volume: default_volume(),
             sidebar_width: f32::from(DEFAULT_SIDEBAR_WIDTH),
             queue_width: f32::from(DEFAULT_QUEUE_WIDTH),
             table_settings: HashMap::new(),
@@ -96,9 +103,7 @@ impl Storage {
                         Some(current_track) if !current_track.get_path().exists() => StorageData {
                             current_track: None,
                             // Preserve other settings when invalidating current_track
-                            sidebar_width: data.sidebar_width,
-                            queue_width: data.queue_width,
-                            table_settings: data.table_settings,
+                            ..data
                         },
                         _ => data,
                     })

--- a/src/ui/models.rs
+++ b/src/ui/models.rs
@@ -263,8 +263,6 @@ pub fn build_models(cx: &mut App, queue: Queue, storage_data: &StorageData) {
         table_settings,
     });
 
-    const DEFAULT_VOLUME: f64 = 1.0;
-
     let position: Entity<u64> = cx.new(|_| 0);
     let duration: Entity<u64> = cx.new(|_| 0);
     let playback_state: Entity<PlaybackState> = cx.new(|_| PlaybackState::Stopped);
@@ -280,8 +278,8 @@ pub fn build_models(cx: &mut App, queue: Queue, storage_data: &StorageData) {
             RepeatState::NotRepeating
         }
     });
-    let volume: Entity<f64> = cx.new(|_| DEFAULT_VOLUME);
-    let prev_volume: Entity<f64> = cx.new(|_| DEFAULT_VOLUME);
+    let volume: Entity<f64> = cx.new(|_| storage_data.volume);
+    let prev_volume: Entity<f64> = cx.new(|_| storage_data.volume);
 
     cx.set_global(PlaybackInfo {
         position,


### PR DESCRIPTION
saves the `PlaybackInfo` volume setting to persistent storage and hands it to the `PlaybackThread` initializer.