### PR TITLE
fix: prevent hang when scanning missing directory

### DIFF
--- a/src/library/scan.rs
+++ b/src/library/scan.rs
@@ -389,7 +389,13 @@ impl ScanThread {
             return;
         }
 
-        let paths = fs::read_dir(&path).unwrap();
+        let paths = match fs::read_dir(&path) {
+            Ok(paths) => paths,
+            Err(e) => {
+                error!("Failed to read directory {:?}: {:?}", path, e);
+                return;
+            }
+        };
 
         for paths in paths {
             let path = match paths {


### PR DESCRIPTION
this may fix #53, but i don't have a windows computer & external drive to test with so it could be separate.

my use case is mounting a network drive on macOS, from my home server running samba, which causes hummingbird to hang if it isn't mounted on launch. with this, it instead logs the error and skips the scanning:
```
   0.451872917s ERROR scanner hummingbird::library::scan: Failed to read directory "/Volumes/drive/media/music": Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

i would love to use hummingbird with subsonic or jellyfin instead if possible. i'd be happy to look into an implementation of this if there's nothing blocking it, but i know you said it's not a priority currently.