### PR TITLE
feat: add close window action

### DIFF
--- a/src/ui/global_actions.rs
+++ b/src/ui/global_actions.rs
@@ -1,6 +1,6 @@
 use cntp_i18n::tr;
-use gpui::{App, KeyBinding, actions};
-use tracing::{debug, info};
+use gpui::{App, AppContext, KeyBinding, actions};
+use tracing::{debug, info, warn};
 
 use crate::{
     library::{db::LibraryAccess, scan::ScanInterface},
@@ -14,7 +14,7 @@ use crate::{
 
 use super::models::{Models, PlaybackInfo};
 
-actions!(hummingbird, [Quit, About, Search, Settings]);
+actions!(hummingbird, [Quit, About, CloseWindow, Search, Settings]);
 actions!(player, [PlayPause, Next, Previous, ShuffleAll]);
 actions!(scan, [ForceScan, Scan]);
 actions!(hummingbird, [HideSelf, HideOthers, ShowAll]);
@@ -23,6 +23,7 @@ actions!(help, [Discord, Patreon, Issues]);
 pub fn register_actions(cx: &mut App) {
     debug!("registering actions");
     cx.on_action(quit);
+    cx.on_action(close_window);
     cx.on_action(play_pause);
     cx.on_action(next);
     cx.on_action(previous);
@@ -56,6 +57,11 @@ pub fn register_actions(cx: &mut App) {
     cx.bind_keys([KeyBinding::new("secondary-f", Search, None)]);
     cx.bind_keys([KeyBinding::new("secondary-shift-p", OpenPalette, None)]);
     cx.bind_keys([KeyBinding::new("secondary-,", Settings, None)]);
+    cx.bind_keys([KeyBinding::new(
+        "escape",
+        CloseWindow,
+        Some("SettingsWindow && !TextInput"),
+    )]);
 
     cx.bind_keys([KeyBinding::new("alt-shift-s", ForceScan, None)]);
     cx.bind_keys([KeyBinding::new("shift-s", Scan, Some("!TextInput"))]);
@@ -141,6 +147,18 @@ pub fn register_actions(cx: &mut App) {
 fn quit(_: &Quit, cx: &mut App) {
     info!("Quitting...");
     cx.quit();
+}
+
+fn close_window(_: &CloseWindow, cx: &mut App) {
+    cx.defer(|cx| {
+        let Some(window_id) = cx.active_window() else {
+            warn!("No active window to close");
+            return;
+        };
+        _ = cx.update_window(window_id, |_, window, _| {
+            window.remove_window();
+        })
+    });
 }
 
 fn play_pause(_: &PlayPause, cx: &mut App) {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -4,10 +4,10 @@ mod playback;
 
 use cntp_i18n::tr;
 use gpui::{
-    App, AppContext, Context, Entity, InteractiveElement, IntoElement, ParentElement, Render,
-    ScrollHandle, SharedString, StatefulInteractiveElement, Styled, TitlebarOptions, Window,
-    WindowBackgroundAppearance, WindowBounds, WindowDecorations, WindowKind, WindowOptions, div,
-    prelude::FluentBuilder, px,
+    App, AppContext, Context, Entity, FocusHandle, InteractiveElement, IntoElement, ParentElement,
+    Render, ScrollHandle, SharedString, StatefulInteractiveElement, Styled, TitlebarOptions,
+    Window, WindowBackgroundAppearance, WindowBounds, WindowDecorations, WindowKind, WindowOptions,
+    div, prelude::FluentBuilder, px,
 };
 
 use crate::{
@@ -69,20 +69,30 @@ enum SettingsSection {
 struct SettingsWindow {
     active: SettingsSection,
     scroll_handle: ScrollHandle,
+    focus_handle: FocusHandle,
+    first_render: bool,
 }
 
 impl SettingsWindow {
     fn new(cx: &mut App) -> gpui::Entity<Self> {
+        let focus_handle = cx.focus_handle();
         let interface = interface::InterfaceSettings::new(cx);
         cx.new(|_| Self {
             active: SettingsSection::Interface(interface),
             scroll_handle: ScrollHandle::new(),
+            first_render: true,
+            focus_handle,
         })
     }
 }
 
 impl Render for SettingsWindow {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if self.first_render {
+            self.first_render = false;
+            self.focus_handle.focus(window, cx);
+        }
+
         let theme = cx.global::<Theme>();
         let active = &self.active;
         let scroll_handle = self.scroll_handle.clone();
@@ -94,107 +104,117 @@ impl Render for SettingsWindow {
         };
 
         window_chrome(
-            div().size_full().flex().flex_col().child(header()).child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .flex_shrink()
-                    .flex_grow()
-                    .min_h(px(0.0))
-                    .child(
-                        sidebar()
-                            .width(DEFAULT_SIDEBAR_WIDTH)
-                            .h_full()
-                            .pt(px(8.0))
-                            .pb(px(8.0))
-                            .pl(px(8.0))
-                            .pr(px(7.0))
-                            .border_r_1()
-                            .border_color(theme.border_color)
-                            .overflow_hidden()
-                            .flex()
-                            .flex_col()
-                            .flex_shrink_0()
-                            .child(
-                                sidebar_item("interface")
-                                    .icon(WORLD)
-                                    .child(tr!("INTERFACE", "Interface"))
-                                    .on_click(cx.listener({
-                                        let scroll_handle = self.scroll_handle.clone();
-                                        move |this, _, _, cx| {
-                                            this.active = SettingsSection::Interface(
-                                                InterfaceSettings::new(cx),
-                                            );
-                                            scroll_handle.scroll_to_top_of_item(0);
-                                            cx.notify();
-                                        }
-                                    }))
-                                    .when(
-                                        matches!(active, SettingsSection::Interface(_)),
-                                        |this| this.active(),
-                                    ),
-                            )
-                            .child(
-                                sidebar_item("library")
-                                    .icon(BOOKS)
-                                    .child(tr!("LIBRARY", "Library"))
-                                    .on_click({
-                                        let scroll_handle = self.scroll_handle.clone();
-                                        cx.listener(move |this, _, _, cx| {
-                                            this.active =
-                                                SettingsSection::Library(LibrarySettings::new(cx));
-                                            scroll_handle.scroll_to_top_of_item(0);
-                                            cx.notify();
+            div()
+                .track_focus(&self.focus_handle)
+                .key_context("SettingsWindow")
+                .size_full()
+                .flex()
+                .flex_col()
+                .child(header())
+                .child(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .flex_shrink()
+                        .flex_grow()
+                        .min_h(px(0.0))
+                        .child(
+                            sidebar()
+                                .width(DEFAULT_SIDEBAR_WIDTH)
+                                .h_full()
+                                .pt(px(8.0))
+                                .pb(px(8.0))
+                                .pl(px(8.0))
+                                .pr(px(7.0))
+                                .border_r_1()
+                                .border_color(theme.border_color)
+                                .overflow_hidden()
+                                .flex()
+                                .flex_col()
+                                .flex_shrink_0()
+                                .child(
+                                    sidebar_item("interface")
+                                        .icon(WORLD)
+                                        .child(tr!("INTERFACE", "Interface"))
+                                        .on_click(cx.listener({
+                                            let scroll_handle = self.scroll_handle.clone();
+                                            move |this, _, _, cx| {
+                                                this.active = SettingsSection::Interface(
+                                                    InterfaceSettings::new(cx),
+                                                );
+                                                scroll_handle.scroll_to_top_of_item(0);
+                                                cx.notify();
+                                            }
+                                        }))
+                                        .when(
+                                            matches!(active, SettingsSection::Interface(_)),
+                                            |this| this.active(),
+                                        ),
+                                )
+                                .child(
+                                    sidebar_item("library")
+                                        .icon(BOOKS)
+                                        .child(tr!("LIBRARY", "Library"))
+                                        .on_click({
+                                            let scroll_handle = self.scroll_handle.clone();
+                                            cx.listener(move |this, _, _, cx| {
+                                                this.active = SettingsSection::Library(
+                                                    LibrarySettings::new(cx),
+                                                );
+                                                scroll_handle.scroll_to_top_of_item(0);
+                                                cx.notify();
+                                            })
                                         })
-                                    })
-                                    .when(matches!(active, SettingsSection::Library(_)), |this| {
-                                        this.active()
-                                    }),
-                            )
-                            .child(
-                                sidebar_item("playback")
-                                    .icon(PLAY)
-                                    .child(tr!("PLAYBACK", "Playback"))
-                                    .on_click({
-                                        let scroll_handle = self.scroll_handle.clone();
-                                        cx.listener(move |this, _, _, cx| {
-                                            this.active = SettingsSection::Playback(
-                                                PlaybackSettings::new(cx),
-                                            );
-                                            scroll_handle.scroll_to_top_of_item(0);
-                                            cx.notify();
+                                        .when(
+                                            matches!(active, SettingsSection::Library(_)),
+                                            |this| this.active(),
+                                        ),
+                                )
+                                .child(
+                                    sidebar_item("playback")
+                                        .icon(PLAY)
+                                        .child(tr!("PLAYBACK", "Playback"))
+                                        .on_click({
+                                            let scroll_handle = self.scroll_handle.clone();
+                                            cx.listener(move |this, _, _, cx| {
+                                                this.active = SettingsSection::Playback(
+                                                    PlaybackSettings::new(cx),
+                                                );
+                                                scroll_handle.scroll_to_top_of_item(0);
+                                                cx.notify();
+                                            })
                                         })
-                                    })
-                                    .when(matches!(active, SettingsSection::Playback(_)), |this| {
-                                        this.active()
-                                    }),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .relative()
-                            .flex()
-                            .flex_grow()
-                            .flex_shrink()
-                            .min_h(px(0.0))
-                            .overflow_hidden()
-                            .child(
-                                div()
-                                    .id("settings-content-scroll")
-                                    .w_full()
-                                    .overflow_y_scroll()
-                                    .track_scroll(&scroll_handle)
-                                    .flex_shrink()
-                                    .overflow_x_hidden()
-                                    .child(div().w_full().p(px(16.0)).child(content)),
-                            )
-                            .child(floating_scrollbar(
-                                "settings-scrollbar",
-                                scroll_handle,
-                                RightPad::Pad,
-                            )),
-                    ),
-            ),
+                                        .when(
+                                            matches!(active, SettingsSection::Playback(_)),
+                                            |this| this.active(),
+                                        ),
+                                ),
+                        )
+                        .child(
+                            div()
+                                .relative()
+                                .flex()
+                                .flex_grow()
+                                .flex_shrink()
+                                .min_h(px(0.0))
+                                .overflow_hidden()
+                                .child(
+                                    div()
+                                        .id("settings-content-scroll")
+                                        .w_full()
+                                        .overflow_y_scroll()
+                                        .track_scroll(&scroll_handle)
+                                        .flex_shrink()
+                                        .overflow_x_hidden()
+                                        .child(div().w_full().p(px(16.0)).child(content)),
+                                )
+                                .child(floating_scrollbar(
+                                    "settings-scrollbar",
+                                    scroll_handle,
+                                    RightPad::Pad,
+                                )),
+                        ),
+                ),
         )
     }
 }

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -1,7 +1,7 @@
 {
   "ABOUT": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:67",
+    "definedIn": "src/ui/global_actions.rs:73",
     "plural": false,
     "description": null
   },
@@ -271,7 +271,7 @@
   },
   "COMMAND_PALETTE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:90",
+    "definedIn": "src/ui/global_actions.rs:96",
     "plural": false,
     "description": null
   },
@@ -301,7 +301,7 @@
   },
   "DISCORD": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:127",
+    "definedIn": "src/ui/global_actions.rs:133",
     "plural": false,
     "description": null
   },
@@ -319,7 +319,7 @@
   },
   "GITHUB_ISSUES": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:122",
+    "definedIn": "src/ui/global_actions.rs:128",
     "plural": false,
     "description": null
   },
@@ -337,25 +337,25 @@
   },
   "HELP": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:120",
+    "definedIn": "src/ui/global_actions.rs:126",
     "plural": false,
     "description": null
   },
   "HIDE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:73",
+    "definedIn": "src/ui/global_actions.rs:79",
     "plural": false,
     "description": null
   },
   "HIDE_OTHERS": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:75",
+    "definedIn": "src/ui/global_actions.rs:81",
     "plural": false,
     "description": null
   },
   "INTERFACE": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:121",
+    "definedIn": "src/ui/settings.rs:138",
     "plural": false,
     "description": null
   },
@@ -427,25 +427,25 @@
   },
   "LIBRARY": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:140",
+    "definedIn": "src/ui/settings.rs:157",
     "plural": false,
     "description": null
   },
   "LIBRARY_FORCE_RESCAN": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:106",
+    "definedIn": "src/ui/global_actions.rs:112",
     "plural": false,
     "description": null
   },
   "LIBRARY_SCAN": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:104",
+    "definedIn": "src/ui/global_actions.rs:110",
     "plural": false,
     "description": null
   },
   "LIBRARY_SHUFFLE_ALL": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:99",
+    "definedIn": "src/ui/global_actions.rs:105",
     "plural": false,
     "description": null
   },
@@ -475,7 +475,7 @@
   },
   "PATREON": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:133",
+    "definedIn": "src/ui/global_actions.rs:139",
     "plural": false,
     "description": null
   },
@@ -493,7 +493,7 @@
   },
   "PLAYBACK": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:157",
+    "definedIn": "src/ui/settings.rs:176",
     "plural": false,
     "description": null
   },
@@ -553,7 +553,7 @@
   },
   "QUIT": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:81",
+    "definedIn": "src/ui/global_actions.rs:87",
     "plural": false,
     "description": null
   },
@@ -787,7 +787,7 @@
   },
   "SEARCH": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:94",
+    "definedIn": "src/ui/global_actions.rs:100",
     "plural": false,
     "description": null
   },
@@ -805,7 +805,7 @@
   },
   "SHOW_ALL": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:79",
+    "definedIn": "src/ui/global_actions.rs:85",
     "plural": false,
     "description": null
   },
@@ -937,13 +937,13 @@
   },
   "VIEW": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:85",
+    "definedIn": "src/ui/global_actions.rs:91",
     "plural": false,
     "description": "The View menu. Must *exactly* match the text required by macOS."
   },
   "WINDOW": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:113",
+    "definedIn": "src/ui/global_actions.rs:119",
     "plural": false,
     "description": "The Window menu. Must *exactly* match the text required by macOS."
   }


### PR DESCRIPTION
Closes #130 when merged together with #199

Currently only used for the settings window to close on Escape. Will also be useful when other windows are implemented in the future like a small Now Playing dialog or similar.

Large diff is because of formatting.. happens.