### PR TITLE
fix: increase queue panel maximum width from 450px to 800px

### DIFF
--- a/src/ui/right_sidebar.rs
+++ b/src/ui/right_sidebar.rs
@@ -54,7 +54,7 @@ impl Render for RightSidebar {
 
         resizable("queue-resizable", queue_width, ResizeEdge::Left)
             .min_size(px(225.0))
-            .max_size(px(450.0))
+            .max_size(px(800.0))
             .default_size(DEFAULT_QUEUE_WIDTH)
             .h_full()
             .child(


### PR DESCRIPTION
## Summary

Increases the queue panel's max resize width from 450px to 800px in `src/ui/right_sidebar.rs`.

## Changes

One line: changed `.max_size(px(450.0))` to `.max_size(px(800.0))` on the queue resizable panel.

Closes #187

This contribution was developed with AI assistance (Claude Code).