### PR TITLE
fix(lastfm): reset sign-in button after session confirmation errors

### DIFF
--- a/src/ui/header/lastfm.rs
+++ b/src/ui/header/lastfm.rs
@@ -145,13 +145,20 @@ fn confirm(cx: &mut App, state: Entity<LastFMState>, token: String) {
         .err_into()
         .map(Result::flatten);
     cx.spawn(async move |cx| {
-        let session = get_session.await.inspect_err(|err| {
-            error!(?err, "error getting last.fm session: {err}");
-        })?;
-
-        state.update(cx, move |_, cx| {
-            cx.emit(session);
-        });
+        match get_session.await {
+            Ok(session) => {
+                state.update(cx, move |_, cx| {
+                    cx.emit(session);
+                });
+            }
+            Err(err) => {
+                error!(?err, "error getting last.fm session: {err}");
+                state.update(cx, |m, cx| {
+                    *m = LastFMState::Disconnected;
+                    cx.notify();
+                });
+            }
+        }
 
         anyhow::Ok(())
     })


### PR DESCRIPTION
## Summary
In the case where the browser auth page has been opened but the user clicks the button again before completing the website flow, Last.fm responds without a session payload in that scenario, which previously logged an error and left the UI in "Click to confirm sign in" indefinitely.

## Changes
Handles failures during the final last.fm sign-in confirmation by returning the header button to the disconnected state instead of leaving it stuck in the confirmation prompt.

## Testing
<!-- How did you test these changes? -->

## Checklist
- [ ] No new warnings or clippy lints introduced - if so, explain why
- [ ] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
