### PR TITLE
feat: album covers in tracks view

### DIFF
--- a/src/library/types/table.rs
+++ b/src/library/types/table.rs
@@ -440,15 +440,16 @@ impl TableData<TrackColumn> for Track {
     }
 
     fn get_image_path(&self) -> Option<SharedString> {
-        None
+        self.album_id
+            .map(|album_id| format!("!db://album/{album_id}/thumb").into())
     }
 
     fn get_full_image_key(&self) -> Option<ManagedImageKey> {
-        None
+        self.album_id.map(ManagedImageKey::Album)
     }
 
     fn has_images() -> bool {
-        false
+        true
     }
 
     fn column_monospace(_column: TrackColumn) -> bool {

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -253,7 +253,7 @@
   },
   "COLUMN_ALBUMS": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:532",
+    "definedIn": "src/library/types/table.rs:533",
     "plural": false,
     "description": null
   },
@@ -289,7 +289,7 @@
   },
   "COLUMN_NAME": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:531",
+    "definedIn": "src/library/types/table.rs:532",
     "plural": false,
     "description": null
   },
@@ -301,7 +301,7 @@
   },
   "COLUMN_TRACKS": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:533",
+    "definedIn": "src/library/types/table.rs:534",
     "plural": false,
     "description": null
   },
@@ -1081,7 +1081,7 @@
   },
   "TABLE_ARTISTS": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:555",
+    "definedIn": "src/library/types/table.rs:556",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
Shows album covers in the tracks view. Cherry picked from e9265ce06d212c4da70e20cbe82a4d8c933345b8

## Changes
<!-- What specific changes were made? -->

## Testing
<!-- How did you test these changes? -->

## Checklist
- [ ] No new warnings or clippy lints introduced - if so, explain why
- [ ] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
