### PR TITLE
feat: escape key returns from album detail

### DIFF
--- a/src/ui/components/modal.rs
+++ b/src/ui/components/modal.rs
@@ -5,7 +5,6 @@ use prelude::FluentBuilder;
 
 use crate::ui::{
     constants::{APP_ROUNDING, APP_SHADOW_SIZE},
-    library::LibraryFocusHandle,
     theme::Theme,
 };
 
@@ -100,13 +99,9 @@ impl RenderOnce for Modal {
                     let on_exit_clone = Rc::clone(&on_exit);
                     this.on_any_mouse_down(move |_, window, cx| {
                         on_exit_clone(window, cx);
-                        let handle = cx.global::<LibraryFocusHandle>().0.clone();
-                        handle.focus(window, cx);
                     })
                     .on_action(move |_: &CloseModal, window, cx| {
                         on_exit(window, cx);
-                        let handle = cx.global::<LibraryFocusHandle>().0.clone();
-                        handle.focus(window, cx);
                     })
                 })
                 .child(

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -49,11 +49,6 @@ mod update_playlist;
 
 actions!(library, [NavigateBack, NavigateForward, EscapeBack]);
 
-/// Global holder for the Library's FocusHandle, so that panels (Search, Command Palette)
-/// can restore focus to the Library after closing.
-pub struct LibraryFocusHandle(pub FocusHandle);
-impl Global for LibraryFocusHandle {}
-
 pub fn bind_actions(cx: &mut App) {
     playlist_view::bind_actions(cx);
     cx.bind_keys([
@@ -215,6 +210,7 @@ pub struct Library {
     focus_handle: FocusHandle,
     scroll_state: ScrollStateStorage,
     reclaim_focus: bool,
+    _focus_lost_sub: Option<Subscription>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -414,7 +410,6 @@ impl Library {
             cx.observe(&split_width, |_, _, cx| cx.notify()).detach();
 
             let focus_handle = cx.focus_handle();
-            cx.set_global(LibraryFocusHandle(focus_handle.clone()));
 
             cx.register_command(
                 ("playlist::import", 0),
@@ -447,6 +442,7 @@ impl Library {
                 focus_handle,
                 scroll_state,
                 reclaim_focus: false,
+                _focus_lost_sub: None,
             }
         })
     }
@@ -454,6 +450,11 @@ impl Library {
 
 impl Render for Library {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if self._focus_lost_sub.is_none() {
+            self._focus_lost_sub = Some(cx.on_focus_lost(window, |this, window, _cx| {
+                this.focus_handle.focus(window, _cx);
+            }));
+        }
         if self.reclaim_focus {
             self.reclaim_focus = false;
             self.focus_handle.focus(window, cx);


### PR DESCRIPTION
## Summary
I added Escape hotkey for returning from album.

## Changes
1. In 1st commit, I added Escape hotkey for returning from album.
2. In 2nd commit, I fixed an issue, when Escape hotkey was not working after panels were closed, since main window lost focus, I fixed this and now main panel always receives input when panels are closed.
3. In 3rd commit, I fixed the similar issue when popover is closed (renaming playlist for example). So now it is much better approach for any modal windows, no matter how you close them.

## Testing
I tested with Settings window and all panels (About Hummingbird, Search, Command Palette, Import M3U Playlist) and I also tested with Rename Playlist popover. I tested clusing renaming popover with Escape, with Cancel button or with Rename button. No matter how I close that renaming popover, it was nicely working :)

This is a final message from Claude about that focusing feature and how nicely it handled:
All clean. Here's the final approach:

**`on_focus_lost`** is a GPUI callback that fires "when nothing in the window has focus" — exactly our case. It's registered once on first render, and whenever focus becomes orphaned (modal closed, popover dismissed, buttons clicked that remove the focused element), it automatically refocuses the Library.

This works for all panels, popovers, and any future overlays — no per-component logic needed.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>, as generated by Claude Code