### PR TITLE
feat: remember last location in views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3474,7 +3474,7 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hummingbird"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hummingbird"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Music Player"
 license = "Apache-2.0"

--- a/package/inno/Hummingbird_aarch64.iss
+++ b/package/inno/Hummingbird_aarch64.iss
@@ -2,7 +2,7 @@
 AppName=Hummingbird
 AppPublisher=William Whittaker
 AppPublisherURL=https://mailliw.org
-AppVersion=0.3.0
+AppVersion=0.4.0
 WizardStyle=modern dynamic windows11
 DefaultDirName={autopf}\Hummingbird
 DisableProgramGroupPage=yes

--- a/package/inno/Hummingbird_x86_64.iss
+++ b/package/inno/Hummingbird_x86_64.iss
@@ -2,7 +2,7 @@
 AppName=Hummingbird
 AppPublisher=William Whittaker
 AppPublisherURL=https://mailliw.org
-AppVersion=0.3.0
+AppVersion=0.4.0
 WizardStyle=modern dynamic windows11
 DefaultDirName={autopf}\Hummingbird
 DisableProgramGroupPage=yes

--- a/src/settings/interface.rs
+++ b/src/settings/interface.rs
@@ -37,6 +37,8 @@ pub struct InterfaceSettings {
     #[serde(default)]
     pub two_column_library: bool,
     #[serde(default)]
+    pub remember_last_selection: bool,
+    #[serde(default)]
     pub startup_library_view: StartupLibraryView,
     #[serde(default = "default_grid_min_item_width")]
     pub grid_min_item_width: f32,
@@ -61,6 +63,7 @@ impl Default for InterfaceSettings {
             theme: None,
             full_width_library: false,
             two_column_library: false,
+            remember_last_selection: false,
             startup_library_view: StartupLibraryView::default(),
             grid_min_item_width: DEFAULT_GRID_MIN_ITEM_WIDTH,
             always_show_scrollbars: false,

--- a/src/settings/storage.rs
+++ b/src/settings/storage.rs
@@ -88,6 +88,12 @@ pub struct StorageData {
     /// Fraction (0..1) of the lyrics panel height
     #[serde(default = "default_lyrics_fraction")]
     pub lyrics_fraction: f32,
+    /// Last selected album ID in Albums view (for "remember last selection")
+    #[serde(default)]
+    pub last_album_id: Option<i64>,
+    /// Last selected artist ID in Artists view (for "remember last selection")
+    #[serde(default)]
+    pub last_artist_id: Option<i64>,
 }
 
 impl StorageData {
@@ -120,6 +126,8 @@ impl Default for StorageData {
             liked_tracks_sort_method: default_liked_tracks_sort_method(),
             sidebar_collapsed: false,
             lyrics_fraction: f32::from(DEFAULT_LYRICS_FRACTION),
+            last_album_id: None,
+            last_artist_id: None,
         }
     }
 }
@@ -241,6 +249,8 @@ mod tests {
             liked_tracks_sort_method: LikedTrackSortMethod::RecentlyAddedAsc,
             sidebar_collapsed: true,
             lyrics_fraction: 0.7,
+            last_album_id: Some(42),
+            last_artist_id: Some(7),
         };
 
         let storage = Storage::new(path);
@@ -261,6 +271,8 @@ mod tests {
         );
         assert_eq!(loaded.sidebar_collapsed, expected.sidebar_collapsed);
         assert_eq!(loaded.lyrics_fraction, expected.lyrics_fraction);
+        assert_eq!(loaded.last_album_id, expected.last_album_id);
+        assert_eq!(loaded.last_artist_id, expected.last_artist_id);
 
         let loaded_table = loaded.table_settings.get("tracks").unwrap();
         let expected_table = expected.table_settings.get("tracks").unwrap();
@@ -297,6 +309,8 @@ mod tests {
             liked_tracks_sort_method: LikedTrackSortMethod::TitleDesc,
             sidebar_collapsed: true,
             lyrics_fraction: 0.4,
+            last_album_id: None,
+            last_artist_id: None,
         };
 
         storage.save(&stored);

--- a/src/settings/storage.rs
+++ b/src/settings/storage.rs
@@ -64,6 +64,14 @@ pub struct TableSettings {
     pub view_mode: TableViewModeSetting,
 }
 
+/// A remembered detail-page selection for a library view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum LastDetail {
+    Release { album_id: i64, track_id: Option<i64> },
+    Artist { artist_id: i64 },
+}
+
 /// Data to store while quitting the app
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageData {
@@ -88,12 +96,12 @@ pub struct StorageData {
     /// Fraction (0..1) of the lyrics panel height
     #[serde(default = "default_lyrics_fraction")]
     pub lyrics_fraction: f32,
-    /// Last selected album ID in Albums view (for "remember last selection")
+    /// Last detail page shown in Albums view
     #[serde(default)]
-    pub last_album_id: Option<i64>,
-    /// Last selected artist ID in Artists view (for "remember last selection")
+    pub last_albums_detail: Option<LastDetail>,
+    /// Last detail page shown in Artists view
     #[serde(default)]
-    pub last_artist_id: Option<i64>,
+    pub last_artists_detail: Option<LastDetail>,
 }
 
 impl StorageData {
@@ -126,8 +134,8 @@ impl Default for StorageData {
             liked_tracks_sort_method: default_liked_tracks_sort_method(),
             sidebar_collapsed: false,
             lyrics_fraction: f32::from(DEFAULT_LYRICS_FRACTION),
-            last_album_id: None,
-            last_artist_id: None,
+            last_albums_detail: None,
+            last_artists_detail: None,
         }
     }
 }
@@ -176,7 +184,7 @@ impl Storage {
 
 #[cfg(test)]
 mod tests {
-    use super::{Storage, StorageData, TableSettings, TableViewModeSetting};
+    use super::{LastDetail, Storage, StorageData, TableSettings, TableViewModeSetting};
     use crate::{
         library::db::LikedTrackSortMethod, test_support::TestDir, ui::models::CurrentTrack,
     };
@@ -249,8 +257,8 @@ mod tests {
             liked_tracks_sort_method: LikedTrackSortMethod::RecentlyAddedAsc,
             sidebar_collapsed: true,
             lyrics_fraction: 0.7,
-            last_album_id: Some(42),
-            last_artist_id: Some(7),
+            last_albums_detail: Some(LastDetail::Release { album_id: 42, track_id: None }),
+            last_artists_detail: Some(LastDetail::Artist { artist_id: 7 }),
         };
 
         let storage = Storage::new(path);
@@ -271,8 +279,8 @@ mod tests {
         );
         assert_eq!(loaded.sidebar_collapsed, expected.sidebar_collapsed);
         assert_eq!(loaded.lyrics_fraction, expected.lyrics_fraction);
-        assert_eq!(loaded.last_album_id, expected.last_album_id);
-        assert_eq!(loaded.last_artist_id, expected.last_artist_id);
+        assert_eq!(loaded.last_albums_detail, expected.last_albums_detail);
+        assert_eq!(loaded.last_artists_detail, expected.last_artists_detail);
 
         let loaded_table = loaded.table_settings.get("tracks").unwrap();
         let expected_table = expected.table_settings.get("tracks").unwrap();
@@ -309,8 +317,8 @@ mod tests {
             liked_tracks_sort_method: LikedTrackSortMethod::TitleDesc,
             sidebar_collapsed: true,
             lyrics_fraction: 0.4,
-            last_album_id: None,
-            last_artist_id: None,
+            last_albums_detail: None,
+            last_artists_detail: None,
         };
 
         storage.save(&stored);

--- a/src/settings/storage.rs
+++ b/src/settings/storage.rs
@@ -64,9 +64,8 @@ pub struct TableSettings {
     pub view_mode: TableViewModeSetting,
 }
 
-/// A remembered detail-page selection for a library view.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind")]
+/// A remembered detail-page selection for a library view (session-only, not persisted).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LastDetail {
     Release { album_id: i64, track_id: Option<i64> },
     Artist { artist_id: i64 },
@@ -96,12 +95,6 @@ pub struct StorageData {
     /// Fraction (0..1) of the lyrics panel height
     #[serde(default = "default_lyrics_fraction")]
     pub lyrics_fraction: f32,
-    /// Last detail page shown in Albums view
-    #[serde(default)]
-    pub last_albums_detail: Option<LastDetail>,
-    /// Last detail page shown in Artists view
-    #[serde(default)]
-    pub last_artists_detail: Option<LastDetail>,
 }
 
 impl StorageData {
@@ -134,8 +127,6 @@ impl Default for StorageData {
             liked_tracks_sort_method: default_liked_tracks_sort_method(),
             sidebar_collapsed: false,
             lyrics_fraction: f32::from(DEFAULT_LYRICS_FRACTION),
-            last_albums_detail: None,
-            last_artists_detail: None,
         }
     }
 }
@@ -184,7 +175,7 @@ impl Storage {
 
 #[cfg(test)]
 mod tests {
-    use super::{LastDetail, Storage, StorageData, TableSettings, TableViewModeSetting};
+    use super::{Storage, StorageData, TableSettings, TableViewModeSetting};
     use crate::{
         library::db::LikedTrackSortMethod, test_support::TestDir, ui::models::CurrentTrack,
     };
@@ -257,8 +248,6 @@ mod tests {
             liked_tracks_sort_method: LikedTrackSortMethod::RecentlyAddedAsc,
             sidebar_collapsed: true,
             lyrics_fraction: 0.7,
-            last_albums_detail: Some(LastDetail::Release { album_id: 42, track_id: None }),
-            last_artists_detail: Some(LastDetail::Artist { artist_id: 7 }),
         };
 
         let storage = Storage::new(path);
@@ -279,8 +268,6 @@ mod tests {
         );
         assert_eq!(loaded.sidebar_collapsed, expected.sidebar_collapsed);
         assert_eq!(loaded.lyrics_fraction, expected.lyrics_fraction);
-        assert_eq!(loaded.last_albums_detail, expected.last_albums_detail);
-        assert_eq!(loaded.last_artists_detail, expected.last_artists_detail);
 
         let loaded_table = loaded.table_settings.get("tracks").unwrap();
         let expected_table = expected.table_settings.get("tracks").unwrap();
@@ -317,8 +304,6 @@ mod tests {
             liked_tracks_sort_method: LikedTrackSortMethod::TitleDesc,
             sidebar_collapsed: true,
             lyrics_fraction: 0.4,
-            last_albums_detail: None,
-            last_artists_detail: None,
         };
 
         storage.save(&stored);

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -337,6 +337,8 @@ pub fn run() -> anyhow::Result<()> {
                             let liked_tracks_sort_method =
                                 cx.global::<Models>().liked_tracks_sort_method.clone();
                             let sidebar_collapsed = cx.global::<Models>().sidebar_collapsed.clone();
+                            let last_album_id = cx.global::<Models>().last_album_id.clone();
+                            let last_artist_id = cx.global::<Models>().last_artist_id.clone();
                             move |_, cx| {
                                 let current_track = current_track.read(cx).clone();
                                 let volume = *volume.read(cx);
@@ -347,6 +349,8 @@ pub fn run() -> anyhow::Result<()> {
                                 let table_settings = table_settings.read(cx).clone();
                                 let liked_tracks_sort_method = *liked_tracks_sort_method.read(cx);
                                 let sidebar_collapsed = *sidebar_collapsed.read(cx);
+                                let last_album_id = *last_album_id.read(cx);
+                                let last_artist_id = *last_artist_id.read(cx);
                                 let storage = storage.clone();
                                 cx.background_executor().spawn(async move {
                                     storage.save(&StorageData {
@@ -359,6 +363,8 @@ pub fn run() -> anyhow::Result<()> {
                                         table_settings,
                                         liked_tracks_sort_method,
                                         sidebar_collapsed,
+                                        last_album_id,
+                                        last_artist_id,
                                     });
 
                                     crate::logging::flush();

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -337,8 +337,6 @@ pub fn run() -> anyhow::Result<()> {
                             let liked_tracks_sort_method =
                                 cx.global::<Models>().liked_tracks_sort_method.clone();
                             let sidebar_collapsed = cx.global::<Models>().sidebar_collapsed.clone();
-                            let last_albums_detail = cx.global::<Models>().last_albums_detail.clone();
-                            let last_artists_detail = cx.global::<Models>().last_artists_detail.clone();
                             move |_, cx| {
                                 let current_track = current_track.read(cx).clone();
                                 let volume = *volume.read(cx);
@@ -349,8 +347,6 @@ pub fn run() -> anyhow::Result<()> {
                                 let table_settings = table_settings.read(cx).clone();
                                 let liked_tracks_sort_method = *liked_tracks_sort_method.read(cx);
                                 let sidebar_collapsed = *sidebar_collapsed.read(cx);
-                                let last_albums_detail = *last_albums_detail.read(cx);
-                                let last_artists_detail = *last_artists_detail.read(cx);
                                 let storage = storage.clone();
                                 cx.background_executor().spawn(async move {
                                     storage.save(&StorageData {
@@ -363,8 +359,6 @@ pub fn run() -> anyhow::Result<()> {
                                         table_settings,
                                         liked_tracks_sort_method,
                                         sidebar_collapsed,
-                                        last_albums_detail,
-                                        last_artists_detail,
                                     });
 
                                     crate::logging::flush();

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -337,8 +337,8 @@ pub fn run() -> anyhow::Result<()> {
                             let liked_tracks_sort_method =
                                 cx.global::<Models>().liked_tracks_sort_method.clone();
                             let sidebar_collapsed = cx.global::<Models>().sidebar_collapsed.clone();
-                            let last_album_id = cx.global::<Models>().last_album_id.clone();
-                            let last_artist_id = cx.global::<Models>().last_artist_id.clone();
+                            let last_albums_detail = cx.global::<Models>().last_albums_detail.clone();
+                            let last_artists_detail = cx.global::<Models>().last_artists_detail.clone();
                             move |_, cx| {
                                 let current_track = current_track.read(cx).clone();
                                 let volume = *volume.read(cx);
@@ -349,8 +349,8 @@ pub fn run() -> anyhow::Result<()> {
                                 let table_settings = table_settings.read(cx).clone();
                                 let liked_tracks_sort_method = *liked_tracks_sort_method.read(cx);
                                 let sidebar_collapsed = *sidebar_collapsed.read(cx);
-                                let last_album_id = *last_album_id.read(cx);
-                                let last_artist_id = *last_artist_id.read(cx);
+                                let last_albums_detail = *last_albums_detail.read(cx);
+                                let last_artists_detail = *last_artists_detail.read(cx);
                                 let storage = storage.clone();
                                 cx.background_executor().spawn(async move {
                                     storage.save(&StorageData {
@@ -363,8 +363,8 @@ pub fn run() -> anyhow::Result<()> {
                                         table_settings,
                                         liked_tracks_sort_method,
                                         sidebar_collapsed,
-                                        last_album_id,
-                                        last_artist_id,
+                                        last_albums_detail,
+                                        last_artists_detail,
                                     });
 
                                     crate::logging::flush();

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -328,41 +328,7 @@ impl Library {
             let switcher_model = cx.global::<Models>().switcher_model.clone();
             let scroll_state = ScrollStateStorage::default();
             let initial_message = switcher_model.read(cx).current();
-
-            let interface = &cx
-                .global::<crate::settings::SettingsGlobal>()
-                .model
-                .read(cx)
-                .interface;
-            let two_column = interface.two_column_library;
-            let remember = interface.remember_last_selection;
-
-            let restored_detail = if remember {
-                last_detail_model_for(&initial_message, cx)
-                    .and_then(|model| *model.read(cx))
-                    .map(|d| ViewSwitchMessage::from_last_detail(&d))
-            } else {
-                None
-            };
-
-            let (view, initial_left, initial_right) = if let Some(detail_msg) = &restored_detail {
-                if two_column {
-                    let left = make_view(&initial_message, cx, &switcher_model, &scroll_state);
-                    let right = make_view(detail_msg, cx, &switcher_model, &scroll_state);
-                    (left.clone(), Some(left), Some(right))
-                } else {
-                    // Single-column: auto-navigate to last selection
-                    switcher_model.update(cx, |history, cx| {
-                        history.navigate(*detail_msg);
-                        cx.notify();
-                    });
-                    let view = make_view(detail_msg, cx, &switcher_model, &scroll_state);
-                    (view, None, None)
-                }
-            } else {
-                let view = make_view(&initial_message, cx, &switcher_model, &scroll_state);
-                (view, None, None)
-            };
+            let view = make_view(&initial_message, cx, &switcher_model, &scroll_state);
 
             cx.subscribe(
                 &switcher_model,
@@ -553,8 +519,8 @@ impl Library {
                 navigation_view: NavigationView::new(cx, switcher_model.clone()),
                 sidebar: Sidebar::new(cx, switcher_model.clone()),
                 view,
-                left_view: initial_left,
-                right_view: initial_right,
+                left_view: None,
+                right_view: None,
                 update_playlist: UpdatePlaylist::new(cx, show_update_playlist.clone()),
                 show_update_playlist,
                 focus_handle,

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -417,7 +417,6 @@ impl Library {
                     if remember && is_explicit_nav && current_msg.is_detail_page() {
                         // Determine which key page owns this detail
                         let owner_key = if two_column {
-                            // In two-column mode, the left pane tells us which view we're in
                             match &this.left_view {
                                 Some(LibraryView::Album(_)) => Some(ViewSwitchMessage::Albums),
                                 Some(LibraryView::Artists(_)) => Some(ViewSwitchMessage::Artists),
@@ -435,6 +434,27 @@ impl Library {
                         }
                     }
 
+                    // When explicitly navigating to a key page with a remembered detail,
+                    // push the detail into history as a real entry so Back/Forward work naturally.
+                    if remember && is_explicit_nav && !current_msg.is_detail_page() {
+                        let restored = last_detail_model_for(&current_msg, cx)
+                            .and_then(|model| *model.read(cx))
+                            .map(|d| ViewSwitchMessage::from_last_detail(&d));
+
+                        if let Some(detail_msg) = restored {
+                            // Push into history and update the view
+                            m.update(cx, |history, cx| {
+                                history.navigate(detail_msg);
+                                cx.notify();
+                            });
+                            this.view = make_view(&detail_msg, cx, &m, &this.scroll_state);
+                        }
+                    }
+
+                    // Re-read current message after possible history change above
+                    let current_msg = m.read(cx).current();
+
+                    // Standard two-column layout logic (unchanged from original)
                     if two_column {
                         if current_msg.is_detail_page() {
                             this.right_view = Some(this.view.clone());
@@ -453,40 +473,10 @@ impl Library {
                                     .map(|lm| make_view(lm, cx, &m, &this.scroll_state));
                             }
                         } else {
-                            // Key page: show in left pane
+                            // Key page: show full-width in left pane, clear right
                             this.left_view = Some(this.view.clone());
-
-                            // Restore last selection for the right pane if available
-                            // (only on explicit navigation, not Back/Forward)
-                            if remember && is_explicit_nav {
-                                let restored = last_detail_model_for(&current_msg, cx)
-                                    .and_then(|model| *model.read(cx))
-                                    .map(|d| ViewSwitchMessage::from_last_detail(&d));
-
-                                this.right_view = restored
-                                    .as_ref()
-                                    .map(|msg| make_view(msg, cx, &m, &this.scroll_state));
-                            } else {
-                                this.right_view = None;
-                            }
+                            this.right_view = None;
                         }
-                    } else if remember && is_explicit_nav && !current_msg.is_detail_page() {
-                        // Single-column: auto-navigate to last selection
-                        // (only on explicit navigation, not Back/Forward)
-                        let restored = last_detail_model_for(&current_msg, cx)
-                            .and_then(|model| *model.read(cx))
-                            .map(|d| ViewSwitchMessage::from_last_detail(&d));
-
-                        if let Some(msg) = restored {
-                            m.update(cx, |history, cx| {
-                                history.navigate(msg);
-                                cx.notify();
-                            });
-                            this.view = make_view(&msg, cx, &m, &this.scroll_state);
-                        }
-
-                        this.left_view = None;
-                        this.right_view = None;
                     } else {
                         this.left_view = None;
                         this.right_view = None;

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -293,7 +293,64 @@ impl Library {
             let switcher_model = cx.global::<Models>().switcher_model.clone();
             let scroll_state = ScrollStateStorage::default();
             let initial_message = switcher_model.read(cx).current();
-            let view = make_view(&initial_message, cx, &switcher_model, &scroll_state);
+
+            let interface = &cx
+                .global::<crate::settings::SettingsGlobal>()
+                .model
+                .read(cx)
+                .interface;
+            let two_column = interface.two_column_library;
+            let remember = interface.remember_last_selection;
+
+            let (view, initial_left, initial_right) = if remember && two_column {
+                // Two-column with remember: set up both panes from the start
+                let restored_msg = match initial_message {
+                    ViewSwitchMessage::Albums => {
+                        cx.global::<Models>().last_album_id.read(cx)
+                            .map(|id| ViewSwitchMessage::Release(id, None))
+                    }
+                    ViewSwitchMessage::Artists => {
+                        cx.global::<Models>().last_artist_id.read(cx)
+                            .map(ViewSwitchMessage::Artist)
+                    }
+                    _ => None,
+                };
+
+                let left = make_view(&initial_message, cx, &switcher_model, &scroll_state);
+                let right = restored_msg
+                    .as_ref()
+                    .map(|msg| make_view(msg, cx, &switcher_model, &scroll_state));
+
+                (left.clone(), Some(left), right)
+            } else if remember && !two_column {
+                // Single-column with remember: auto-navigate to last selection
+                let restored_msg = match initial_message {
+                    ViewSwitchMessage::Albums => {
+                        cx.global::<Models>().last_album_id.read(cx)
+                            .map(|id| ViewSwitchMessage::Release(id, None))
+                    }
+                    ViewSwitchMessage::Artists => {
+                        cx.global::<Models>().last_artist_id.read(cx)
+                            .map(ViewSwitchMessage::Artist)
+                    }
+                    _ => None,
+                };
+
+                if let Some(msg) = restored_msg {
+                    switcher_model.update(cx, |history, cx| {
+                        history.navigate(msg);
+                        cx.notify();
+                    });
+                    let view = make_view(&msg, cx, &switcher_model, &scroll_state);
+                    (view, None, None)
+                } else {
+                    let view = make_view(&initial_message, cx, &switcher_model, &scroll_state);
+                    (view, None, None)
+                }
+            } else {
+                let view = make_view(&initial_message, cx, &switcher_model, &scroll_state);
+                (view, None, None)
+            };
 
             cx.subscribe(
                 &switcher_model,
@@ -363,15 +420,32 @@ impl Library {
                         }
                     };
 
-                    let two_column = cx
+                    let interface = &cx
                         .global::<crate::settings::SettingsGlobal>()
                         .model
                         .read(cx)
-                        .interface
-                        .two_column_library;
+                        .interface;
+                    let two_column = interface.two_column_library;
+                    let remember = interface.remember_last_selection;
+
+                    let current_msg = m.read(cx).current();
+
+                    // Save last selection when navigating to a detail page
+                    if remember {
+                        match current_msg {
+                            ViewSwitchMessage::Release(id, _) => {
+                                let model = cx.global::<Models>().last_album_id.clone();
+                                model.update(cx, |v, _| *v = Some(id));
+                            }
+                            ViewSwitchMessage::Artist(id) => {
+                                let model = cx.global::<Models>().last_artist_id.clone();
+                                model.update(cx, |v, _| *v = Some(id));
+                            }
+                            _ => {}
+                        }
+                    }
 
                     if two_column {
-                        let current_msg = m.read(cx).current();
                         if current_msg.is_detail_page() {
                             this.right_view = Some(this.view.clone());
 
@@ -390,10 +464,54 @@ impl Library {
                                     .map(|lm| make_view(lm, cx, &m, &this.scroll_state));
                             }
                         } else {
-                            // Key page: show full-width in left pane, clear right
+                            // Key page: show in left pane
                             this.left_view = Some(this.view.clone());
-                            this.right_view = None;
+
+                            // Restore last selection for the right pane if available
+                            if remember {
+                                let restored_msg = match current_msg {
+                                    ViewSwitchMessage::Albums => {
+                                        cx.global::<Models>().last_album_id.read(cx)
+                                            .map(|id| ViewSwitchMessage::Release(id, None))
+                                    }
+                                    ViewSwitchMessage::Artists => {
+                                        cx.global::<Models>().last_artist_id.read(cx)
+                                            .map(ViewSwitchMessage::Artist)
+                                    }
+                                    _ => None,
+                                };
+
+                                this.right_view = restored_msg
+                                    .as_ref()
+                                    .map(|msg| make_view(msg, cx, &m, &this.scroll_state));
+                            } else {
+                                this.right_view = None;
+                            }
                         }
+                    } else if remember && !current_msg.is_detail_page() {
+                        // Single-column: auto-navigate to last selection
+                        let restored_msg = match current_msg {
+                            ViewSwitchMessage::Albums => {
+                                cx.global::<Models>().last_album_id.read(cx)
+                                    .map(|id| ViewSwitchMessage::Release(id, None))
+                            }
+                            ViewSwitchMessage::Artists => {
+                                cx.global::<Models>().last_artist_id.read(cx)
+                                    .map(ViewSwitchMessage::Artist)
+                            }
+                            _ => None,
+                        };
+
+                        if let Some(msg) = restored_msg {
+                            m.update(cx, |history, cx| {
+                                history.navigate(msg);
+                                cx.notify();
+                            });
+                            this.view = make_view(&msg, cx, &m, &this.scroll_state);
+                        }
+
+                        this.left_view = None;
+                        this.right_view = None;
                     } else {
                         this.left_view = None;
                         this.right_view = None;
@@ -433,8 +551,8 @@ impl Library {
                 navigation_view: NavigationView::new(cx, switcher_model.clone()),
                 sidebar: Sidebar::new(cx, switcher_model.clone()),
                 view,
-                left_view: None,
-                right_view: None,
+                left_view: initial_left,
+                right_view: initial_right,
                 update_playlist: UpdatePlaylist::new(cx, show_update_playlist.clone()),
                 show_update_playlist,
                 focus_handle,

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -457,7 +457,8 @@ impl Library {
                             this.left_view = Some(this.view.clone());
 
                             // Restore last selection for the right pane if available
-                            if remember {
+                            // (only on explicit navigation, not Back/Forward)
+                            if remember && is_explicit_nav {
                                 let restored = last_detail_model_for(&current_msg, cx)
                                     .and_then(|model| *model.read(cx))
                                     .map(|d| ViewSwitchMessage::from_last_detail(&d));
@@ -469,8 +470,9 @@ impl Library {
                                 this.right_view = None;
                             }
                         }
-                    } else if remember && !current_msg.is_detail_page() {
+                    } else if remember && is_explicit_nav && !current_msg.is_detail_page() {
                         // Single-column: auto-navigate to last selection
+                        // (only on explicit navigation, not Back/Forward)
                         let restored = last_detail_model_for(&current_msg, cx)
                             .and_then(|model| *model.read(cx))
                             .map(|d| ViewSwitchMessage::from_last_detail(&d));

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -59,10 +59,15 @@ pub fn bind_actions(cx: &mut App) {
 }
 
 /// The navigation history + a cursor noting what the current message is.
+///
+/// Each entry is a `(ViewSwitchMessage, bool)` pair. The bool is a *skip-on-back* flag: when
+/// `true`, `go_back` will jump over the entry so it never appears as a Back destination. This is
+/// used to hide auto-inserted key-page entries that the user never explicitly saw (e.g. when
+/// "remember last selection" restores a detail page on top of its parent key page).
 #[derive(Debug)]
 pub struct NavigationHistory {
     startup_view: ViewSwitchMessage,
-    history: Vec<ViewSwitchMessage>,
+    history: Vec<(ViewSwitchMessage, bool)>,
     cursor: usize,
 }
 
@@ -70,17 +75,20 @@ impl NavigationHistory {
     pub fn new(startup_view: ViewSwitchMessage) -> Self {
         Self {
             startup_view,
-            history: vec![startup_view],
+            history: vec![(startup_view, false)],
             cursor: 0,
         }
     }
 
     pub fn current(&self) -> ViewSwitchMessage {
-        self.history[self.cursor]
+        self.history[self.cursor].0
     }
 
     pub fn can_go_back(&self) -> bool {
-        self.cursor > 0
+        // Can go back if there is any non-skip entry before the cursor.
+        self.history[..self.cursor]
+            .iter()
+            .any(|(_, skip)| !skip)
     }
 
     pub fn can_go_forward(&self) -> bool {
@@ -88,12 +96,13 @@ impl NavigationHistory {
     }
 
     pub fn go_back(&mut self) -> Option<ViewSwitchMessage> {
-        if self.can_go_back() {
+        while self.cursor > 0 {
             self.cursor -= 1;
-            Some(self.current())
-        } else {
-            None
+            if !self.history[self.cursor].1 {
+                return Some(self.current());
+            }
         }
+        None
     }
 
     pub fn go_forward(&mut self) -> Option<ViewSwitchMessage> {
@@ -121,8 +130,17 @@ impl NavigationHistory {
             }
         }
 
-        self.history.push(message);
+        self.history.push((message, false));
         self.cursor = self.history.len() - 1;
+    }
+
+    /// Marks the entry immediately before the cursor as *skip-on-back*. Used after a restore
+    /// pushes a detail entry on top of its parent key page — the key page should be invisible
+    /// to Back navigation since the user never explicitly viewed it.
+    pub fn mark_preceding_skip_on_back(&mut self) {
+        if self.cursor > 0 {
+            self.history[self.cursor - 1].1 = true;
+        }
     }
 
     fn eviction_index(&self) -> usize {
@@ -130,7 +148,7 @@ impl NavigationHistory {
         let most_recent_key_idx = self
             .history
             .iter()
-            .rposition(ViewSwitchMessage::is_key_page);
+            .rposition(|(m, _)| m.is_key_page());
 
         if most_recent_key_idx == Some(oldest_idx) && self.history.len() > 1 {
             1
@@ -147,8 +165,8 @@ impl NavigationHistory {
         self.history[..self.cursor]
             .iter()
             .rev()
-            .find(|m| pred(m))
-            .copied()
+            .find(|&&(ref m, _)| pred(m))
+            .map(|&(m, _)| m)
     }
 
     /// Removes history entries that do not satisfy `f`, adjusting the cursor so that it continues
@@ -163,13 +181,13 @@ impl NavigationHistory {
         // Count how many entries at or before the cursor will be removed.
         let removed_before_or_at_cursor = self.history[..=self.cursor]
             .iter()
-            .filter(|v| !f(v))
+            .filter(|&&(ref v, _)| !f(v))
             .count();
 
-        self.history.retain(f);
+        self.history.retain(|(v, _)| f(v));
 
         if self.history.is_empty() {
-            self.history.push(self.startup_view);
+            self.history.push((self.startup_view, false));
             self.cursor = 0;
         } else {
             self.cursor = self
@@ -436,6 +454,8 @@ impl Library {
 
                     // When explicitly navigating to a key page with a remembered detail,
                     // push the detail into history as a real entry so Back/Forward work naturally.
+                    // Mark the key-page entry as skip-on-back so Back jumps over it — the user
+                    // never explicitly saw the key page.
                     if remember && is_explicit_nav && !current_msg.is_detail_page() {
                         let restored = last_detail_model_for(&current_msg, cx)
                             .and_then(|model| *model.read(cx))
@@ -445,6 +465,7 @@ impl Library {
                             // Push into history and update the view
                             m.update(cx, |history, cx| {
                                 history.navigate(detail_msg);
+                                history.mark_preceding_skip_on_back();
                                 cx.notify();
                             });
                             this.view = make_view(&detail_msg, cx, &m, &this.scroll_state);

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -408,8 +408,13 @@ impl Library {
 
                     let current_msg = m.read(cx).current();
 
-                    // Save last selection per view when navigating to a detail page
-                    if remember && current_msg.is_detail_page() {
+                    let is_explicit_nav = !matches!(
+                        message,
+                        ViewSwitchMessage::Back | ViewSwitchMessage::Forward | ViewSwitchMessage::Refresh
+                    );
+
+                    // Save last selection per view when explicitly navigating to a detail page
+                    if remember && is_explicit_nav && current_msg.is_detail_page() {
                         // Determine which key page owns this detail
                         let owner_key = if two_column {
                             // In two-column mode, the left pane tells us which view we're in

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -16,7 +16,7 @@ struct ScrollStateStorage {
 }
 
 use crate::{
-    settings::storage::DEFAULT_SPLIT_FRACTION,
+    settings::storage::{DEFAULT_SPLIT_FRACTION, LastDetail},
     ui::{
         command_palette::{Command, CommandManager},
         components::{
@@ -250,6 +250,41 @@ impl ViewSwitchMessage {
                 | (LibraryView::Artists(_), ViewSwitchMessage::Artists)
         )
     }
+
+    fn to_last_detail(&self) -> Option<LastDetail> {
+        match *self {
+            ViewSwitchMessage::Release(album_id, track_id) => {
+                Some(LastDetail::Release { album_id, track_id })
+            }
+            ViewSwitchMessage::Artist(artist_id) => {
+                Some(LastDetail::Artist { artist_id })
+            }
+            _ => None,
+        }
+    }
+
+    fn from_last_detail(detail: &LastDetail) -> Self {
+        match *detail {
+            LastDetail::Release { album_id, track_id } => {
+                ViewSwitchMessage::Release(album_id, track_id)
+            }
+            LastDetail::Artist { artist_id } => {
+                ViewSwitchMessage::Artist(artist_id)
+            }
+        }
+    }
+}
+
+/// Returns the model for the remembered detail of a given key page, if applicable.
+fn last_detail_model_for(
+    key_page: &ViewSwitchMessage,
+    cx: &App,
+) -> Option<Entity<Option<LastDetail>>> {
+    match key_page {
+        ViewSwitchMessage::Albums => Some(cx.global::<Models>().last_albums_detail.clone()),
+        ViewSwitchMessage::Artists => Some(cx.global::<Models>().last_artists_detail.clone()),
+        _ => None,
+    }
 }
 
 fn make_view(
@@ -302,49 +337,26 @@ impl Library {
             let two_column = interface.two_column_library;
             let remember = interface.remember_last_selection;
 
-            let (view, initial_left, initial_right) = if remember && two_column {
-                // Two-column with remember: set up both panes from the start
-                let restored_msg = match initial_message {
-                    ViewSwitchMessage::Albums => {
-                        cx.global::<Models>().last_album_id.read(cx)
-                            .map(|id| ViewSwitchMessage::Release(id, None))
-                    }
-                    ViewSwitchMessage::Artists => {
-                        cx.global::<Models>().last_artist_id.read(cx)
-                            .map(ViewSwitchMessage::Artist)
-                    }
-                    _ => None,
-                };
+            let restored_detail = if remember {
+                last_detail_model_for(&initial_message, cx)
+                    .and_then(|model| *model.read(cx))
+                    .map(|d| ViewSwitchMessage::from_last_detail(&d))
+            } else {
+                None
+            };
 
-                let left = make_view(&initial_message, cx, &switcher_model, &scroll_state);
-                let right = restored_msg
-                    .as_ref()
-                    .map(|msg| make_view(msg, cx, &switcher_model, &scroll_state));
-
-                (left.clone(), Some(left), right)
-            } else if remember && !two_column {
-                // Single-column with remember: auto-navigate to last selection
-                let restored_msg = match initial_message {
-                    ViewSwitchMessage::Albums => {
-                        cx.global::<Models>().last_album_id.read(cx)
-                            .map(|id| ViewSwitchMessage::Release(id, None))
-                    }
-                    ViewSwitchMessage::Artists => {
-                        cx.global::<Models>().last_artist_id.read(cx)
-                            .map(ViewSwitchMessage::Artist)
-                    }
-                    _ => None,
-                };
-
-                if let Some(msg) = restored_msg {
+            let (view, initial_left, initial_right) = if let Some(detail_msg) = &restored_detail {
+                if two_column {
+                    let left = make_view(&initial_message, cx, &switcher_model, &scroll_state);
+                    let right = make_view(detail_msg, cx, &switcher_model, &scroll_state);
+                    (left.clone(), Some(left), Some(right))
+                } else {
+                    // Single-column: auto-navigate to last selection
                     switcher_model.update(cx, |history, cx| {
-                        history.navigate(msg);
+                        history.navigate(*detail_msg);
                         cx.notify();
                     });
-                    let view = make_view(&msg, cx, &switcher_model, &scroll_state);
-                    (view, None, None)
-                } else {
-                    let view = make_view(&initial_message, cx, &switcher_model, &scroll_state);
+                    let view = make_view(detail_msg, cx, &switcher_model, &scroll_state);
                     (view, None, None)
                 }
             } else {
@@ -430,18 +442,25 @@ impl Library {
 
                     let current_msg = m.read(cx).current();
 
-                    // Save last selection when navigating to a detail page
-                    if remember {
-                        match current_msg {
-                            ViewSwitchMessage::Release(id, _) => {
-                                let model = cx.global::<Models>().last_album_id.clone();
-                                model.update(cx, |v, _| *v = Some(id));
+                    // Save last selection per view when navigating to a detail page
+                    if remember && current_msg.is_detail_page() {
+                        // Determine which key page owns this detail
+                        let owner_key = if two_column {
+                            // In two-column mode, the left pane tells us which view we're in
+                            match &this.left_view {
+                                Some(LibraryView::Album(_)) => Some(ViewSwitchMessage::Albums),
+                                Some(LibraryView::Artists(_)) => Some(ViewSwitchMessage::Artists),
+                                _ => m.read(cx).last_matching(ViewSwitchMessage::is_key_page),
                             }
-                            ViewSwitchMessage::Artist(id) => {
-                                let model = cx.global::<Models>().last_artist_id.clone();
-                                model.update(cx, |v, _| *v = Some(id));
+                        } else {
+                            m.read(cx).last_matching(ViewSwitchMessage::is_key_page)
+                        };
+
+                        if let Some(key) = owner_key {
+                            if let Some(model) = last_detail_model_for(&key, cx) {
+                                let detail = current_msg.to_last_detail();
+                                model.update(cx, |v, _| *v = detail);
                             }
-                            _ => {}
                         }
                     }
 
@@ -453,7 +472,6 @@ impl Library {
 
                             let needs_new_left = match (&this.left_view, &left_msg) {
                                 (None, Some(_)) | (Some(_), None) => true,
-
                                 (Some(lv), Some(msg)) => !msg.library_view_matches(lv),
                                 (None, None) => false,
                             };
@@ -469,19 +487,11 @@ impl Library {
 
                             // Restore last selection for the right pane if available
                             if remember {
-                                let restored_msg = match current_msg {
-                                    ViewSwitchMessage::Albums => {
-                                        cx.global::<Models>().last_album_id.read(cx)
-                                            .map(|id| ViewSwitchMessage::Release(id, None))
-                                    }
-                                    ViewSwitchMessage::Artists => {
-                                        cx.global::<Models>().last_artist_id.read(cx)
-                                            .map(ViewSwitchMessage::Artist)
-                                    }
-                                    _ => None,
-                                };
+                                let restored = last_detail_model_for(&current_msg, cx)
+                                    .and_then(|model| *model.read(cx))
+                                    .map(|d| ViewSwitchMessage::from_last_detail(&d));
 
-                                this.right_view = restored_msg
+                                this.right_view = restored
                                     .as_ref()
                                     .map(|msg| make_view(msg, cx, &m, &this.scroll_state));
                             } else {
@@ -490,19 +500,11 @@ impl Library {
                         }
                     } else if remember && !current_msg.is_detail_page() {
                         // Single-column: auto-navigate to last selection
-                        let restored_msg = match current_msg {
-                            ViewSwitchMessage::Albums => {
-                                cx.global::<Models>().last_album_id.read(cx)
-                                    .map(|id| ViewSwitchMessage::Release(id, None))
-                            }
-                            ViewSwitchMessage::Artists => {
-                                cx.global::<Models>().last_artist_id.read(cx)
-                                    .map(ViewSwitchMessage::Artist)
-                            }
-                            _ => None,
-                        };
+                        let restored = last_detail_model_for(&current_msg, cx)
+                            .and_then(|model| *model.read(cx))
+                            .map(|d| ViewSwitchMessage::from_last_detail(&d));
 
-                        if let Some(msg) = restored_msg {
+                        if let Some(msg) = restored {
                             m.update(cx, |history, cx| {
                                 history.navigate(msg);
                                 cx.notify();

--- a/src/ui/models.rs
+++ b/src/ui/models.rs
@@ -72,6 +72,8 @@ pub struct Models {
     pub liked_tracks_sort_method: Entity<LikedTrackSortMethod>,
     pub sidebar_collapsed: Entity<bool>,
     pub lyrics_height: Entity<Pixels>,
+    pub last_album_id: Entity<Option<i64>>,
+    pub last_artist_id: Entity<Option<i64>>,
     #[cfg(feature = "update")]
     pub pending_update: Entity<Option<PathBuf>>,
 }
@@ -353,6 +355,9 @@ pub fn build_models(
         }
     });
 
+    let last_album_id: Entity<Option<i64>> = cx.new(|_| storage_data.last_album_id);
+    let last_artist_id: Entity<Option<i64>> = cx.new(|_| storage_data.last_artist_id);
+
     #[cfg(feature = "update")]
     let pending_update = cx.new(|_| None);
 
@@ -374,6 +379,8 @@ pub fn build_models(
         liked_tracks_sort_method,
         sidebar_collapsed,
         lyrics_height,
+        last_album_id,
+        last_artist_id,
         #[cfg(feature = "update")]
         pending_update,
     });

--- a/src/ui/models.rs
+++ b/src/ui/models.rs
@@ -355,8 +355,8 @@ pub fn build_models(
         }
     });
 
-    let last_albums_detail = cx.new(|_| storage_data.last_albums_detail);
-    let last_artists_detail = cx.new(|_| storage_data.last_artists_detail);
+    let last_albums_detail = cx.new(|_| None);
+    let last_artists_detail = cx.new(|_| None);
 
     #[cfg(feature = "update")]
     let pending_update = cx.new(|_| None);

--- a/src/ui/models.rs
+++ b/src/ui/models.rs
@@ -72,8 +72,8 @@ pub struct Models {
     pub liked_tracks_sort_method: Entity<LikedTrackSortMethod>,
     pub sidebar_collapsed: Entity<bool>,
     pub lyrics_height: Entity<Pixels>,
-    pub last_album_id: Entity<Option<i64>>,
-    pub last_artist_id: Entity<Option<i64>>,
+    pub last_albums_detail: Entity<Option<crate::settings::storage::LastDetail>>,
+    pub last_artists_detail: Entity<Option<crate::settings::storage::LastDetail>>,
     #[cfg(feature = "update")]
     pub pending_update: Entity<Option<PathBuf>>,
 }
@@ -355,8 +355,8 @@ pub fn build_models(
         }
     });
 
-    let last_album_id: Entity<Option<i64>> = cx.new(|_| storage_data.last_album_id);
-    let last_artist_id: Entity<Option<i64>> = cx.new(|_| storage_data.last_artist_id);
+    let last_albums_detail = cx.new(|_| storage_data.last_albums_detail);
+    let last_artists_detail = cx.new(|_| storage_data.last_artists_detail);
 
     #[cfg(feature = "update")]
     let pending_update = cx.new(|_| None);
@@ -379,8 +379,8 @@ pub fn build_models(
         liked_tracks_sort_method,
         sidebar_collapsed,
         lyrics_height,
-        last_album_id,
-        last_artist_id,
+        last_albums_detail,
+        last_artists_detail,
         #[cfg(feature = "update")]
         pending_update,
     });

--- a/src/ui/settings/interface.rs
+++ b/src/ui/settings/interface.rs
@@ -258,6 +258,27 @@ impl Render for InterfaceSettings {
             )
             .child(
                 label(
+                    "interface-remember-last-selection",
+                    tr!("INTERFACE_REMEMBER_LAST_SELECTION", "Remember last selection"),
+                )
+                .subtext(tr!(
+                    "INTERFACE_REMEMBER_LAST_SELECTION_SUBTEXT",
+                    "Remember the last opened album or artist in Albums and Artists views."
+                ))
+                .cursor_pointer()
+                .w_full()
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.update_interface(cx, |interface| {
+                        interface.remember_last_selection = !interface.remember_last_selection;
+                    });
+                }))
+                .child(checkbox(
+                    "interface-remember-last-selection-check",
+                    interface.remember_last_selection,
+                )),
+            )
+            .child(
+                label(
                     "interface-full-width-library",
                     tr!("INTERFACE_GRID_MIN_ITEM_WIDTH", "Grid item width"),
                 )

--- a/translations/en.json
+++ b/translations/en.json
@@ -74,6 +74,8 @@
   "INTERFACE_FULL_WIDTH_LIBRARY_SUBTEXT": "Allows the library to take up the full width of the screen.",
   "INTERFACE_GRID_MIN_ITEM_WIDTH": "Grid item width",
   "INTERFACE_GRID_MIN_ITEM_WIDTH_SUBTEXT": "Adjusts the minimum width of items in grid view.",
+  "INTERFACE_REMEMBER_LAST_SELECTION": "Remember last selection",
+  "INTERFACE_REMEMBER_LAST_SELECTION_SUBTEXT": "Remember the last opened album or artist in Albums and Artists views.",
   "INTERFACE_STARTUP_LIBRARY_VIEW": "Default startup view",
   "INTERFACE_STARTUP_LIBRARY_VIEW_SUBTEXT": "Choose which library page opens when Hummingbird launches.",
   "INTERFACE_THEME": "Theme",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -97,7 +97,7 @@
   },
   "ACTION_GROUP_PLAYLIST": {
     "context": "library.rs",
-    "definedIn": "src/ui/library.rs:415",
+    "definedIn": "src/ui/library.rs:519",
     "plural": false,
     "description": null
   },
@@ -109,7 +109,7 @@
   },
   "ACTION_IMPORT_PLAYLIST": {
     "context": "library.rs",
-    "definedIn": "src/ui/library.rs:416",
+    "definedIn": "src/ui/library.rs:520",
     "plural": false,
     "description": null
   },
@@ -415,13 +415,13 @@
   },
   "INTERFACE_ALWAYS_SHOW_SCROLLBARS": {
     "context": "interface.rs",
-    "definedIn": "src/ui/settings/interface.rs:291",
+    "definedIn": "src/ui/settings/interface.rs:312",
     "plural": false,
     "description": null
   },
   "INTERFACE_ALWAYS_SHOW_SCROLLBARS_SUBTEXT": {
     "context": "interface.rs",
-    "definedIn": "src/ui/settings/interface.rs:294",
+    "definedIn": "src/ui/settings/interface.rs:315",
     "plural": false,
     "description": null
   },
@@ -439,11 +439,23 @@
   },
   "INTERFACE_GRID_MIN_ITEM_WIDTH": {
     "context": "interface.rs",
-    "definedIn": "src/ui/settings/interface.rs:262",
+    "definedIn": "src/ui/settings/interface.rs:283",
     "plural": false,
     "description": null
   },
   "INTERFACE_GRID_MIN_ITEM_WIDTH_SUBTEXT": {
+    "context": "interface.rs",
+    "definedIn": "src/ui/settings/interface.rs:286",
+    "plural": false,
+    "description": null
+  },
+  "INTERFACE_REMEMBER_LAST_SELECTION": {
+    "context": "interface.rs",
+    "definedIn": "src/ui/settings/interface.rs:262",
+    "plural": false,
+    "description": null
+  },
+  "INTERFACE_REMEMBER_LAST_SELECTION_SUBTEXT": {
     "context": "interface.rs",
     "definedIn": "src/ui/settings/interface.rs:265",
     "plural": false,


### PR DESCRIPTION
Albums and Artists views now remembers location when switched to different view and back.
So in Albums, it remembers last opened album
And in Artist, it remembers last open Artist or even last open Album

It remembers it only per session, so after Hummingbird restarts, it is not saved.
Some people may like if it saves permanently, and I have it worked like that first, but it has few problems now, so those would need to be solved first to make this correct. Navigation history is not saved across restarts, and so it wouldn't be really compatible...

There is still another little issue with this. When I open some album in Artists view, this correctly remembers that, but when I go to Albums and select some album and go back to Artists, now when I press back action, it just takes me back to Albums view, since that is what was last navigation step. But the user might wanted to just go up from album and see all albums of the artist...

So it means, navigation history could maybe be independent for specific views. Indeed, only Artists and Albums view would have navigation, since Tracks, Liked Song, or Playlist views are flat, and you cannot open anything inside them.
So while working on this issue, I realized it could maybe work better if navigation history is separate for each view.

If you disagree with this, then I am going to at least improve the Escape hotkey I did today, so it doesn't use navigation history to go back from album, but it just returns from album no matter navigation history. I will probably makes this change anyway, since it only makes so much sense, to make Escape hotkey for returning from album independent of navigation history.

Testing
I tested very well, I was thinking a lot about this, and it's not easy to decide, what is the most correct behavior.
So I would like you to first test it, if you like how it currently works, and maybe even tell me, how you think it should work.

Co-Authored-By: Claude Opus 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com), as generated by Claude Code