### PR TITLE
fix: refine navigation handling for escape key

### DIFF
--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -89,6 +89,15 @@ impl NavigationHistory {
         self.cursor < self.history.len() - 1
     }
 
+    /// Returns the history entry immediately before the cursor, if any.
+    pub fn previous(&self) -> Option<ViewSwitchMessage> {
+        if self.cursor > 0 {
+            Some(self.history[self.cursor - 1])
+        } else {
+            None
+        }
+    }
+
     pub fn go_back(&mut self) -> Option<ViewSwitchMessage> {
         if self.can_go_back() {
             self.cursor -= 1;
@@ -646,8 +655,15 @@ impl Render for Library {
                 };
 
                 if let Some(dest) = parent {
+                    // If the previous history entry matches the parent, go back
+                    // instead of creating a new history entry.
+                    let msg = if switcher.read(cx).previous() == Some(dest) {
+                        ViewSwitchMessage::Back
+                    } else {
+                        dest
+                    };
                     switcher.update(cx, |_, cx| {
-                        cx.emit(dest);
+                        cx.emit(msg);
                     });
                 }
             }))

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -97,7 +97,7 @@
   },
   "ACTION_GROUP_PLAYLIST": {
     "context": "library.rs",
-    "definedIn": "src/ui/library.rs:479",
+    "definedIn": "src/ui/library.rs:488",
     "plural": false,
     "description": null
   },
@@ -109,7 +109,7 @@
   },
   "ACTION_IMPORT_PLAYLIST": {
     "context": "library.rs",
-    "definedIn": "src/ui/library.rs:480",
+    "definedIn": "src/ui/library.rs:489",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
It was always creating navigation history states, but now it only creates when coming to different navigation step as the previous one

## Changes
NavigationHistory::previous()`** — new method that peeks at the history entry before the cursor without modifying state.

**`EscapeBack` handler** — before emitting the parent destination, it now checks if `previous() == Some(dest)`. If the previous history entry already *is* the parent view, it emits `Back` (which decrements the cursor, popping the current entry) instead of emitting the destination directly (which would push a duplicate entry). If the previous entry is something else (e.g., you came from a different view), it navigates normally.

## Testing
I tested this behavior in both Albums and Artists views, and it works now in both.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>, as generated by Claude Code