### PR TITLE
feat: show total duration on album and playlist pages

### DIFF
--- a/queries/playlist/get_all_playlists.sql
+++ b/queries/playlist/get_all_playlists.sql
@@ -1,1 +1,1 @@
-SELECT playlist.*, COUNT(playlist_item.id) as track_count FROM playlist LEFT JOIN playlist_item ON playlist.id = playlist_item.playlist_id GROUP BY playlist.id;
+SELECT playlist.*, COUNT(playlist_item.id) as track_count, COALESCE(SUM(track.duration), 0) as total_duration FROM playlist LEFT JOIN playlist_item ON playlist.id = playlist_item.playlist_id LEFT JOIN track ON playlist_item.track_id = track.id GROUP BY playlist.id;

--- a/queries/playlist/get_playlist.sql
+++ b/queries/playlist/get_playlist.sql
@@ -1,1 +1,12 @@
-SELECT * FROM playlist WHERE id = $1;
+SELECT
+    playlist.id,
+    playlist.name,
+    playlist.created_at,
+    playlist.type,
+    COUNT(playlist_item.id) as track_count,
+    COALESCE(SUM(track.duration), 0) as total_duration
+FROM playlist
+LEFT JOIN playlist_item ON playlist.id = playlist_item.playlist_id
+LEFT JOIN track ON playlist_item.track_id = track.id
+WHERE playlist.id = $1
+GROUP BY playlist.id;

--- a/src/library/db.rs
+++ b/src/library/db.rs
@@ -9,7 +9,7 @@ use sqlx::{
 use tracing::debug;
 
 use crate::{
-    library::types::{ArtistWithCounts, PlaylistItem, PlaylistWithCount, TrackStats},
+    library::types::{ArtistWithCounts, Playlist, PlaylistItem, TrackStats},
     ui::app::Pool,
 };
 
@@ -497,21 +497,18 @@ pub async fn rename_playlist(pool: &SqlitePool, playlist_id: i64, name: &str) ->
     Ok(())
 }
 
-pub async fn get_all_playlists(pool: &SqlitePool) -> sqlx::Result<Arc<Vec<PlaylistWithCount>>> {
+pub async fn get_all_playlists(pool: &SqlitePool) -> sqlx::Result<Arc<Vec<Playlist>>> {
     let query = include_str!("../../queries/playlist/get_all_playlists.sql");
 
-    let playlists: Vec<PlaylistWithCount> = sqlx::query_as(query).fetch_all(pool).await?;
+    let playlists: Vec<Playlist> = sqlx::query_as(query).fetch_all(pool).await?;
 
     Ok(Arc::new(playlists))
 }
 
-pub async fn get_playlist(
-    pool: &SqlitePool,
-    playlist_id: i64,
-) -> sqlx::Result<Arc<PlaylistWithCount>> {
+pub async fn get_playlist(pool: &SqlitePool, playlist_id: i64) -> sqlx::Result<Arc<Playlist>> {
     let query = include_str!("../../queries/playlist/get_playlist.sql");
 
-    let playlist: PlaylistWithCount = sqlx::query_as(query)
+    let playlist: Playlist = sqlx::query_as(query)
         .bind(playlist_id)
         .fetch_one(pool)
         .await?;
@@ -724,8 +721,8 @@ pub trait LibraryAccess {
     fn create_playlist(&self, name: &str) -> sqlx::Result<i64>;
     fn delete_playlist(&self, playlist_id: i64) -> sqlx::Result<()>;
     fn rename_playlist(&self, playlist_id: i64, name: &str) -> sqlx::Result<()>;
-    fn get_all_playlists(&self) -> sqlx::Result<Arc<Vec<PlaylistWithCount>>>;
-    fn get_playlist(&self, playlist_id: i64) -> sqlx::Result<Arc<PlaylistWithCount>>;
+    fn get_all_playlists(&self) -> sqlx::Result<Arc<Vec<Playlist>>>;
+    fn get_playlist(&self, playlist_id: i64) -> sqlx::Result<Arc<Playlist>>;
     fn get_playlist_track_files(&self, playlist_id: i64) -> sqlx::Result<Arc<Vec<String>>>;
     fn get_playlist_tracks(&self, playlist_id: i64) -> sqlx::Result<Arc<Vec<(i64, i64, i64)>>>;
     fn get_playlist_tracks_sorted(
@@ -827,12 +824,12 @@ impl LibraryAccess for App {
         crate::RUNTIME.block_on(rename_playlist(&pool.0, playlist_id, name))
     }
 
-    fn get_all_playlists(&self) -> sqlx::Result<Arc<Vec<PlaylistWithCount>>> {
+    fn get_all_playlists(&self) -> sqlx::Result<Arc<Vec<Playlist>>> {
         let pool: &Pool = self.global();
         crate::RUNTIME.block_on(get_all_playlists(&pool.0))
     }
 
-    fn get_playlist(&self, playlist_id: i64) -> sqlx::Result<Arc<PlaylistWithCount>> {
+    fn get_playlist(&self, playlist_id: i64) -> sqlx::Result<Arc<Playlist>> {
         let pool: &Pool = self.global();
         crate::RUNTIME.block_on(get_playlist(&pool.0, playlist_id))
     }

--- a/src/library/db.rs
+++ b/src/library/db.rs
@@ -9,7 +9,7 @@ use sqlx::{
 use tracing::debug;
 
 use crate::{
-    library::types::{ArtistWithCounts, Playlist, PlaylistItem, PlaylistWithCount, TrackStats},
+    library::types::{ArtistWithCounts, PlaylistItem, PlaylistWithCount, TrackStats},
     ui::app::Pool,
 };
 
@@ -505,10 +505,13 @@ pub async fn get_all_playlists(pool: &SqlitePool) -> sqlx::Result<Arc<Vec<Playli
     Ok(Arc::new(playlists))
 }
 
-pub async fn get_playlist(pool: &SqlitePool, playlist_id: i64) -> sqlx::Result<Arc<Playlist>> {
+pub async fn get_playlist(
+    pool: &SqlitePool,
+    playlist_id: i64,
+) -> sqlx::Result<Arc<PlaylistWithCount>> {
     let query = include_str!("../../queries/playlist/get_playlist.sql");
 
-    let playlist: Playlist = sqlx::query_as(query)
+    let playlist: PlaylistWithCount = sqlx::query_as(query)
         .bind(playlist_id)
         .fetch_one(pool)
         .await?;
@@ -722,7 +725,7 @@ pub trait LibraryAccess {
     fn delete_playlist(&self, playlist_id: i64) -> sqlx::Result<()>;
     fn rename_playlist(&self, playlist_id: i64, name: &str) -> sqlx::Result<()>;
     fn get_all_playlists(&self) -> sqlx::Result<Arc<Vec<PlaylistWithCount>>>;
-    fn get_playlist(&self, playlist_id: i64) -> sqlx::Result<Arc<Playlist>>;
+    fn get_playlist(&self, playlist_id: i64) -> sqlx::Result<Arc<PlaylistWithCount>>;
     fn get_playlist_track_files(&self, playlist_id: i64) -> sqlx::Result<Arc<Vec<String>>>;
     fn get_playlist_tracks(&self, playlist_id: i64) -> sqlx::Result<Arc<Vec<(i64, i64, i64)>>>;
     fn get_playlist_tracks_sorted(
@@ -829,7 +832,7 @@ impl LibraryAccess for App {
         crate::RUNTIME.block_on(get_all_playlists(&pool.0))
     }
 
-    fn get_playlist(&self, playlist_id: i64) -> sqlx::Result<Arc<Playlist>> {
+    fn get_playlist(&self, playlist_id: i64) -> sqlx::Result<Arc<PlaylistWithCount>> {
         let pool: &Pool = self.global();
         crate::RUNTIME.block_on(get_playlist(&pool.0, playlist_id))
     }

--- a/src/library/types.rs
+++ b/src/library/types.rs
@@ -282,7 +282,6 @@ pub struct PlaylistWithCount {
     #[sqlx(rename = "type")]
     pub playlist_type: PlaylistType,
     pub track_count: i64,
-    #[sqlx(default)]
     pub total_duration: i64,
 }
 

--- a/src/library/types.rs
+++ b/src/library/types.rs
@@ -282,6 +282,8 @@ pub struct PlaylistWithCount {
     #[sqlx(rename = "type")]
     pub playlist_type: PlaylistType,
     pub track_count: i64,
+    #[sqlx(default)]
+    pub total_duration: i64,
 }
 
 impl PlaylistWithCount {

--- a/src/library/types.rs
+++ b/src/library/types.rs
@@ -260,7 +260,7 @@ pub enum PlaylistType {
 }
 
 #[derive(sqlx::FromRow, Clone, Debug, PartialEq)]
-pub struct PlaylistWithCount {
+pub struct Playlist {
     pub id: i64,
     pub name: DBString,
     pub created_at: DateTime<Utc>,
@@ -270,7 +270,7 @@ pub struct PlaylistWithCount {
     pub total_duration: i64,
 }
 
-impl PlaylistWithCount {
+impl Playlist {
     pub fn is_liked_songs(&self) -> bool {
         self.playlist_type == PlaylistType::System && self.name.0.as_str() == "Liked Songs"
     }

--- a/src/library/types.rs
+++ b/src/library/types.rs
@@ -260,21 +260,6 @@ pub enum PlaylistType {
 }
 
 #[derive(sqlx::FromRow, Clone, Debug, PartialEq)]
-pub struct Playlist {
-    pub id: i64,
-    pub name: DBString,
-    pub created_at: DateTime<Utc>,
-    #[sqlx(rename = "type")]
-    pub playlist_type: PlaylistType,
-}
-
-impl Playlist {
-    pub fn is_liked_songs(&self) -> bool {
-        self.playlist_type == PlaylistType::System && self.name.0.as_str() == "Liked Songs"
-    }
-}
-
-#[derive(sqlx::FromRow, Clone, Debug, PartialEq)]
 pub struct PlaylistWithCount {
     pub id: i64,
     pub name: DBString,

--- a/src/library/types/table.rs
+++ b/src/library/types/table.rs
@@ -25,6 +25,7 @@ use crate::{
             AlbumContextMenuContext, TrackContextMenuContext, album_menu_for_table,
             play_album_next, play_track_next, track_menu_for_table,
         },
+        util::format_duration,
     },
 };
 
@@ -431,11 +432,7 @@ impl TableData<TrackColumn> for Track {
                     None
                 }
             }
-            TrackColumn::Length => {
-                let minutes = self.duration / 60;
-                let seconds = self.duration % 60;
-                Some(format!("{:02}:{:02}", minutes, seconds).into())
-            }
+            TrackColumn::Length => Some(format_duration(self.duration, true).into()),
         }
     }
 

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -719,7 +719,7 @@ impl Render for Scrubber {
                         div()
                             .mr(px(6.0))
                             .line_height(rems(1.0))
-                            .child(format_duration(position_secs as i64)),
+                            .child(format_duration(position_secs as i64, true)),
                     )
                     .when(window_width > px(900.0), |this| {
                         this.child(
@@ -729,7 +729,7 @@ impl Render for Scrubber {
                                 .border_l(px(2.0))
                                 .pl(px(6.0))
                                 .text_color(rgb(0xcbd5e1))
-                                .child(format_duration(duration_secs as i64)),
+                                .child(format_duration(duration_secs as i64, true)),
                         )
                     })
                     .child(self.playback_section.clone())
@@ -738,7 +738,7 @@ impl Render for Scrubber {
                         div()
                             .ml(auto())
                             .line_height(rems(1.0))
-                            .child(format!("-{}", format_duration(remaining_secs as i64))),
+                            .child(format!("-{}", format_duration(remaining_secs as i64, true))),
                     ),
             )
             .child(

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -42,6 +42,7 @@ use super::{
 };
 
 use crate::settings::storage::{DEFAULT_CONTROLS_LEFT_WIDTH, DEFAULT_CONTROLS_RIGHT_WIDTH};
+use crate::ui::util::format_duration;
 
 pub struct Controls {
     info_section: Entity<InfoSection>,
@@ -714,11 +715,12 @@ impl Render for Scrubber {
                     .items_end()
                     .mt(px(6.0))
                     .mb(px(6.0))
-                    .child(div().mr(px(6.0)).line_height(rems(1.0)).child(format!(
-                        "{:02}:{:02}",
-                        position_secs / 60,
-                        position_secs % 60
-                    )))
+                    .child(
+                        div()
+                            .mr(px(6.0))
+                            .line_height(rems(1.0))
+                            .child(format_duration(position_secs as i64)),
+                    )
                     .when(window_width > px(900.0), |this| {
                         this.child(
                             div()
@@ -727,20 +729,17 @@ impl Render for Scrubber {
                                 .border_l(px(2.0))
                                 .pl(px(6.0))
                                 .text_color(rgb(0xcbd5e1))
-                                .child(format!(
-                                    "{:02}:{:02}",
-                                    duration_secs / 60,
-                                    duration_secs % 60
-                                )),
+                                .child(format_duration(duration_secs as i64)),
                         )
                     })
                     .child(self.playback_section.clone())
                     .child(div().h(px(30.0)))
-                    .child(div().ml(auto()).line_height(rems(1.0)).child(format!(
-                        "-{:02}:{:02}",
-                        remaining_secs / 60,
-                        remaining_secs % 60
-                    ))),
+                    .child(
+                        div()
+                            .ml(auto())
+                            .line_height(rems(1.0))
+                            .child(format!("-{}", format_duration(remaining_secs as i64))),
+                    ),
             )
             .child(
                 slider()

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -37,6 +37,7 @@ pub mod add_to_playlist;
 mod album_view;
 mod artist_detail_view;
 mod artist_view;
+mod collection_summary;
 pub mod context_menus;
 pub mod missing_folder_dialog;
 pub mod nav_buttons;

--- a/src/ui/library/add_to_playlist.rs
+++ b/src/ui/library/add_to_playlist.rs
@@ -11,7 +11,7 @@ use tracing::error;
 use crate::{
     library::{
         db::{self, LibraryAccess},
-        types::PlaylistWithCount,
+        types::Playlist,
     },
     ui::{
         app::Pool,
@@ -25,7 +25,7 @@ use crate::{
 };
 
 // i64 here is the track ID
-impl PaletteItem for (i64, PlaylistWithCount) {
+impl PaletteItem for (i64, Playlist) {
     fn left_content(&self, cx: &mut App) -> Option<FinderItemLeft> {
         self.1.left_content(cx)
     }
@@ -55,12 +55,12 @@ impl PaletteItem for (i64, PlaylistWithCount) {
     }
 }
 
-type MatcherFunc = Box<dyn Fn(&Arc<(i64, PlaylistWithCount)>, &mut App) -> Utf32String + 'static>;
-type OnAccept = Box<dyn Fn(&Arc<(i64, PlaylistWithCount)>, &mut App) + 'static>;
+type MatcherFunc = Box<dyn Fn(&Arc<(i64, Playlist)>, &mut App) -> Utf32String + 'static>;
+type OnAccept = Box<dyn Fn(&Arc<(i64, Playlist)>, &mut App) + 'static>;
 
 pub struct AddToPlaylist {
     show: Entity<bool>,
-    palette: Entity<Palette<(i64, PlaylistWithCount), MatcherFunc, OnAccept>>,
+    palette: Entity<Palette<(i64, Playlist), MatcherFunc, OnAccept>>,
 }
 
 impl AddToPlaylist {

--- a/src/ui/library/album_view.rs
+++ b/src/ui/library/album_view.rs
@@ -9,10 +9,7 @@ use crate::{
     },
     ui::{
         components::table::{Table, TableEvent, table_data::TABLE_MAX_WIDTH},
-        library::{
-            context_menus::AlbumContextMenuContext,
-            table_view_header::TableViewHeader,
-        },
+        library::{context_menus::AlbumContextMenuContext, table_view_header::TableViewHeader},
         models::Models,
     },
 };

--- a/src/ui/library/artist_view.rs
+++ b/src/ui/library/artist_view.rs
@@ -13,10 +13,7 @@ use crate::{
     },
 };
 
-use super::{
-    NavigationHistory, ViewSwitchMessage,
-    table_view_header::TableViewHeader,
-};
+use super::{NavigationHistory, ViewSwitchMessage, table_view_header::TableViewHeader};
 
 #[derive(Clone)]
 pub struct ArtistView {

--- a/src/ui/library/collection_summary.rs
+++ b/src/ui/library/collection_summary.rs
@@ -1,0 +1,32 @@
+use cntp_i18n::trn;
+use gpui::SharedString;
+
+pub fn format_collection_summary(track_count: i64, total_duration: i64) -> SharedString {
+    let track_label = format!(
+        "{}",
+        trn!(
+            "COLLECTION_SUMMARY_TRACKS",
+            "{{count}} track",
+            "{{count}} tracks",
+            count = track_count
+        )
+    );
+
+    SharedString::from(format!(
+        "{track_label} • {}",
+        format_total_duration(total_duration)
+    ))
+}
+
+fn format_total_duration(total_duration: i64) -> String {
+    let total_duration = total_duration.max(0);
+    let hours = total_duration / 3_600;
+    let minutes = (total_duration % 3_600) / 60;
+    let seconds = total_duration % 60;
+
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes}:{seconds:02}")
+    }
+}

--- a/src/ui/library/collection_summary.rs
+++ b/src/ui/library/collection_summary.rs
@@ -13,6 +13,6 @@ pub fn format_collection_summary(track_count: i64, total_duration: i64) -> Share
 
     SharedString::from(format!(
         "{track_label} • {}",
-        format_duration(total_duration)
+        format_duration(total_duration, false)
     ))
 }

--- a/src/ui/library/collection_summary.rs
+++ b/src/ui/library/collection_summary.rs
@@ -1,6 +1,8 @@
 use cntp_i18n::trn;
 use gpui::SharedString;
 
+use crate::ui::util::format_duration;
+
 pub fn format_collection_summary(track_count: i64, total_duration: i64) -> SharedString {
     let track_label = trn!(
         "COLLECTION_SUMMARY_TRACKS",
@@ -11,19 +13,6 @@ pub fn format_collection_summary(track_count: i64, total_duration: i64) -> Share
 
     SharedString::from(format!(
         "{track_label} • {}",
-        format_total_duration(total_duration)
+        format_duration(total_duration)
     ))
-}
-
-fn format_total_duration(total_duration: i64) -> String {
-    let total_duration = total_duration.max(0);
-    let hours = total_duration / 3_600;
-    let minutes = (total_duration % 3_600) / 60;
-    let seconds = total_duration % 60;
-
-    if hours > 0 {
-        format!("{hours}:{minutes:02}:{seconds:02}")
-    } else {
-        format!("{minutes}:{seconds:02}")
-    }
 }

--- a/src/ui/library/collection_summary.rs
+++ b/src/ui/library/collection_summary.rs
@@ -2,14 +2,11 @@ use cntp_i18n::trn;
 use gpui::SharedString;
 
 pub fn format_collection_summary(track_count: i64, total_duration: i64) -> SharedString {
-    let track_label = format!(
-        "{}",
-        trn!(
-            "COLLECTION_SUMMARY_TRACKS",
-            "{{count}} track",
-            "{{count}} tracks",
-            count = track_count
-        )
+    let track_label = trn!(
+        "COLLECTION_SUMMARY_TRACKS",
+        "{{count}} track",
+        "{{count}} tracks",
+        count = track_count
     );
 
     SharedString::from(format!(

--- a/src/ui/library/playlist_view.rs
+++ b/src/ui/library/playlist_view.rs
@@ -14,7 +14,7 @@ use crate::{
     library::{
         db::{LibraryAccess, PlaylistTrackSortMethod},
         playlist::export_playlist,
-        types::{PlaylistType, PlaylistWithCount},
+        types::{Playlist, PlaylistType},
     },
     playback::queue::QueueItemData,
     ui::{
@@ -179,7 +179,7 @@ impl Render for PlaylistTrackItem {
 }
 
 pub struct PlaylistView {
-    playlist: Arc<PlaylistWithCount>,
+    playlist: Arc<Playlist>,
     playlist_track_ids: Arc<Vec<(i64, i64, i64)>>,
     views: Entity<FxHashMap<usize, Entity<PlaylistTrackItem>>>,
     render_counter: Entity<usize>,

--- a/src/ui/library/playlist_view.rs
+++ b/src/ui/library/playlist_view.rs
@@ -14,7 +14,7 @@ use crate::{
     library::{
         db::{LibraryAccess, PlaylistTrackSortMethod},
         playlist::export_playlist,
-        types::{Playlist, PlaylistType},
+        types::{PlaylistType, PlaylistWithCount},
     },
     playback::queue::QueueItemData,
     ui::{
@@ -34,6 +34,7 @@ use crate::{
             table::table_data::TABLE_MAX_WIDTH,
             tooltip::build_tooltip,
         },
+        library::collection_summary::format_collection_summary,
         library::track_listing::{
             ArtistNameVisibility,
             track_item::{TrackItem, TrackItemLeftField},
@@ -178,7 +179,7 @@ impl Render for PlaylistTrackItem {
 }
 
 pub struct PlaylistView {
-    playlist: Arc<Playlist>,
+    playlist: Arc<PlaylistWithCount>,
     playlist_track_ids: Arc<Vec<(i64, i64, i64)>>,
     views: Entity<FxHashMap<usize, Entity<PlaylistTrackItem>>>,
     render_counter: Entity<usize>,
@@ -217,6 +218,7 @@ impl PlaylistView {
                     if let PlaylistEvent::PlaylistUpdated(id) = ev
                         && *id == this.playlist.id
                     {
+                        this.playlist = cx.get_playlist(this.playlist.id).unwrap();
                         this.playlist_track_ids = cx
                             .get_playlist_tracks_sorted(this.playlist.id, this.sort_method)
                             .unwrap();
@@ -436,6 +438,8 @@ impl Render for PlaylistView {
         let playlist_id = self.playlist.id;
         let is_custom_sort = self.is_custom_sort();
         let current_sort = self.sort_method;
+        let collection_summary =
+            format_collection_summary(self.playlist.track_count, self.playlist.total_duration);
 
         if self.first_render {
             self.first_render = false;
@@ -541,6 +545,13 @@ impl Render for PlaylistView {
                                             } else {
                                                 div().child(self.playlist.name.clone())
                                             }),
+                                    )
+                                    .child(
+                                        div()
+                                            .pb(px(10.0))
+                                            .text_sm()
+                                            .text_color(theme.text_secondary)
+                                            .child(collection_summary),
                                     )
                                     .child(
                                         div()

--- a/src/ui/library/release_view.rs
+++ b/src/ui/library/release_view.rs
@@ -23,6 +23,7 @@ use crate::{
         },
         library::{
             ViewSwitchMessage,
+            collection_summary::format_collection_summary,
             track_listing::{ArtistNameVisibility, TrackListing},
         },
         models::{Models, PlaybackInfo},
@@ -38,6 +39,7 @@ pub struct ReleaseView {
     artist_name: Option<DBString>,
     tracks: Arc<Vec<Track>>,
     track_listing: TrackListing,
+    collection_summary: SharedString,
     release_info: Option<SharedString>,
     img_path: SharedString,
     scroll_handle: ScrollHandle,
@@ -74,6 +76,10 @@ impl ReleaseView {
                 false,
                 true,
             );
+            let collection_summary = format_collection_summary(
+                tracks.len() as i64,
+                tracks.iter().map(|track| track.duration).sum(),
+            );
 
             let release_info = {
                 let mut info = String::default();
@@ -108,6 +114,7 @@ impl ReleaseView {
                 artist_name,
                 tracks,
                 track_listing,
+                collection_summary,
                 release_info,
                 img_path: SharedString::from(format!("!db://album/{album_id}/full")),
                 scroll_handle: ScrollHandle::new(),
@@ -193,6 +200,13 @@ impl ReleaseView {
                             .w_full()
                             .text_ellipsis()
                             .child(self.album.title.clone()),
+                    )
+                    .child(
+                        div()
+                            .pb(px(10.0))
+                            .text_sm()
+                            .text_color(theme.text_secondary)
+                            .child(self.collection_summary.clone()),
                     )
                     .child(playback_controls(
                         "release",

--- a/src/ui/library/sidebar/playlists.rs
+++ b/src/ui/library/sidebar/playlists.rs
@@ -12,7 +12,7 @@ use crate::{
     library::{
         db::LibraryAccess,
         playlist::export_playlist,
-        types::{PlaylistType, PlaylistWithCount},
+        types::{PlaylistType, Playlist},
     },
     playback::interface::PlaybackInterface,
     settings::SettingsGlobal,
@@ -34,7 +34,7 @@ use crate::{
 };
 
 pub struct PlaylistList {
-    playlists: Arc<Vec<PlaylistWithCount>>,
+    playlists: Arc<Vec<Playlist>>,
     nav_model: Entity<NavigationHistory>,
     scroll_handle: ScrollHandle,
     popover_open: bool,

--- a/src/ui/library/track_listing/track_item.rs
+++ b/src/ui/library/track_listing/track_item.rs
@@ -389,7 +389,7 @@ impl Render for TrackItem {
                                             .pl(px(10.0))
                                             .border_color(theme.border_color)
                                             .text_align(TextAlign::Right)
-                                            .child(format_duration(self.track.duration)),
+                                            .child(format_duration(self.track.duration, false)),
                                     ),
                             ),
                     )

--- a/src/ui/library/track_listing/track_item.rs
+++ b/src/ui/library/track_listing/track_item.rs
@@ -11,6 +11,7 @@ use crate::ui::components::icons::{STAR, STAR_FILLED, icon};
 use crate::ui::library::context_menus::play_track_next;
 use crate::ui::library::context_menus::track::TrackContextMenu;
 use crate::ui::models::PlaylistEvent;
+use crate::ui::util::format_duration;
 use crate::{
     library::{
         db::{self, LibraryAccess},
@@ -388,11 +389,7 @@ impl Render for TrackItem {
                                             .pl(px(10.0))
                                             .border_color(theme.border_color)
                                             .text_align(TextAlign::Right)
-                                            .child(format!(
-                                                "{}:{:02}",
-                                                self.track.duration / 60,
-                                                self.track.duration % 60
-                                            )),
+                                            .child(format_duration(self.track.duration)),
                                     ),
                             ),
                     )

--- a/src/ui/library/track_view.rs
+++ b/src/ui/library/track_view.rs
@@ -22,8 +22,6 @@ use crate::{
         models::Models,
     },
 };
-
-
 #[derive(Clone)]
 pub struct TrackView {
     table_view_header: Entity<TableViewHeader<Track, TrackColumn>>,

--- a/src/ui/library/update_playlist.rs
+++ b/src/ui/library/update_playlist.rs
@@ -11,7 +11,7 @@ use crate::{
     library::{
         db::LibraryAccess,
         playlist::import_playlist,
-        types::{PlaylistType, PlaylistWithCount},
+        types::{PlaylistType, Playlist},
     },
     ui::components::{
         icons::{PLAYLIST, PLAYLIST_ADD, STAR_FILLED},
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 
-impl PaletteItem for PlaylistWithCount {
+impl PaletteItem for Playlist {
     fn left_content(&self, _: &mut App) -> Option<FinderItemLeft> {
         Some(FinderItemLeft::Icon(match self.playlist_type {
             PlaylistType::User => PLAYLIST.into(),
@@ -42,12 +42,12 @@ impl PaletteItem for PlaylistWithCount {
     }
 }
 
-type MatcherFunc = Box<dyn Fn(&Arc<PlaylistWithCount>, &mut App) -> Utf32String + 'static>;
-type OnAccept = Box<dyn Fn(&Arc<PlaylistWithCount>, &mut App) + 'static>;
+type MatcherFunc = Box<dyn Fn(&Arc<Playlist>, &mut App) -> Utf32String + 'static>;
+type OnAccept = Box<dyn Fn(&Arc<Playlist>, &mut App) + 'static>;
 
 pub struct UpdatePlaylist {
     show: Entity<bool>,
-    palette: Entity<Palette<PlaylistWithCount, MatcherFunc, OnAccept>>,
+    palette: Entity<Palette<Playlist, MatcherFunc, OnAccept>>,
 }
 
 impl UpdatePlaylist {

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -1,3 +1,4 @@
+use crate::ui::util::format_duration;
 use crate::{
     library::db::LibraryAccess,
     playback::{interface::PlaybackInterface, queue::QueueItemData},
@@ -258,11 +259,7 @@ impl Render for QueueItem {
                                                     .ml(px(6.0))
                                                     .font_weight(FontWeight::SEMIBOLD)
                                                     .text_color(theme.text_secondary)
-                                                    .child(format!(
-                                                        "{:02}:{:02}",
-                                                        duration / 60,
-                                                        duration % 60
-                                                    )),
+                                                    .child(format_duration(duration)),
                                             )
                                         }),
                                 ),

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -259,7 +259,7 @@ impl Render for QueueItem {
                                                     .ml(px(6.0))
                                                     .font_weight(FontWeight::SEMIBOLD)
                                                     .text_color(theme.text_secondary)
-                                                    .child(format_duration(duration)),
+                                                    .child(format_duration(duration, true)),
                                             )
                                         }),
                                 ),

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -247,7 +247,7 @@ where
     }
 }
 
-pub fn format_duration(secs: i64) -> String {
+pub fn format_duration(secs: i64, pad_minutes: bool) -> String {
     let secs = secs.max(0);
     let hours = secs / 3_600;
     let minutes = (secs % 3_600) / 60;
@@ -255,6 +255,8 @@ pub fn format_duration(secs: i64) -> String {
 
     if hours > 0 {
         format!("{hours}:{minutes:02}:{seconds:02}")
+    } else if pad_minutes {
+        format!("{minutes:02}:{seconds:02}")
     } else {
         format!("{minutes:02}:{seconds:02}")
     }

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -258,7 +258,7 @@ pub fn format_duration(secs: i64, pad_minutes: bool) -> String {
     } else if pad_minutes {
         format!("{minutes:02}:{seconds:02}")
     } else {
-        format!("{minutes:02}:{seconds:02}")
+        format!("{minutes}:{seconds:02}")
     }
 }
 

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -256,7 +256,7 @@ pub fn format_duration(secs: i64) -> String {
     if hours > 0 {
         format!("{hours}:{minutes:02}:{seconds:02}")
     } else {
-        format!("{minutes}:{seconds:02}")
+        format!("{minutes:02}:{seconds:02}")
     }
 }
 

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -247,6 +247,19 @@ where
     }
 }
 
+pub fn format_duration(secs: i64) -> String {
+    let secs = secs.max(0);
+    let hours = secs / 3_600;
+    let minutes = (secs % 3_600) / 60;
+    let seconds = secs % 60;
+
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes}:{seconds:02}")
+    }
+}
+
 pub fn find_art_file_for_path(path: &Path) -> Option<Arc<Path>> {
     let parent = path.parent()?;
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -40,6 +40,10 @@
   "CLICK_TO_CONFIRM": "Click to confirm sign in",
   "CLOSE": "Close",
   "COLLAPSE_SIDEBAR": "Collapse Sidebar",
+  "COLLECTION_SUMMARY_TRACKS": {
+    "one": "{{count}} track",
+    "other": "{{count}} tracks"
+  },
   "COLUMN_ALBUM": "Album",
   "COLUMN_ALBUMS": "# of Albums",
   "COLUMN_ARTIST": "Artist",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -187,7 +187,7 @@
   },
   "APP_NAME": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:302",
+    "definedIn": "src/ui/controls.rs:303",
     "plural": false,
     "description": "Use the english name everywhere unless this is strictly disagreeable.\n                                "
   },
@@ -223,7 +223,7 @@
   },
   "CLEAR_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:493",
+    "definedIn": "src/ui/queue.rs:490",
     "plural": false,
     "description": null
   },
@@ -235,7 +235,7 @@
   },
   "CLOSE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:478",
+    "definedIn": "src/ui/queue.rs:475",
     "plural": false,
     "description": null
   },
@@ -247,7 +247,7 @@
   },
   "COLLECTION_SUMMARY_TRACKS": {
     "context": "collection_summary.rs",
-    "definedIn": "src/ui/library/collection_summary.rs:6",
+    "definedIn": "src/ui/library/collection_summary.rs:8",
     "plural": true,
     "description": null
   },
@@ -385,13 +385,13 @@
   },
   "GO_TO_ALBUM": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:278",
+    "definedIn": "src/ui/queue.rs:275",
     "plural": false,
     "description": null
   },
   "GO_TO_ARTIST": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:295",
+    "definedIn": "src/ui/queue.rs:292",
     "plural": false,
     "description": null
   },
@@ -553,13 +553,13 @@
   },
   "LYRICS": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:965",
+    "definedIn": "src/ui/controls.rs:954",
     "plural": false,
     "description": null
   },
   "MUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:900",
+    "definedIn": "src/ui/controls.rs:889",
     "plural": false,
     "description": null
   },
@@ -571,7 +571,7 @@
   },
   "NEXT_TRACK": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:552",
+    "definedIn": "src/ui/controls.rs:553",
     "plural": false,
     "description": null
   },
@@ -673,13 +673,13 @@
   },
   "PREVIOUS_TRACK": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:500",
+    "definedIn": "src/ui/controls.rs:501",
     "plural": false,
     "description": null
   },
   "QUEUE_TITLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:471",
+    "definedIn": "src/ui/queue.rs:468",
     "plural": false,
     "description": null
   },
@@ -721,7 +721,7 @@
   },
   "REMOVE_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:327",
+    "definedIn": "src/ui/queue.rs:324",
     "plural": false,
     "description": null
   },
@@ -745,19 +745,19 @@
   },
   "REPEAT": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:634",
+    "definedIn": "src/ui/controls.rs:635",
     "plural": false,
     "description": null
   },
   "REPEAT_OFF": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:624",
+    "definedIn": "src/ui/controls.rs:625",
     "plural": false,
     "description": null
   },
   "REPEAT_ONE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:643",
+    "definedIn": "src/ui/controls.rs:644",
     "plural": false,
     "description": null
   },
@@ -1009,13 +1009,13 @@
   },
   "SHUFFLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:506",
+    "definedIn": "src/ui/queue.rs:503",
     "plural": false,
     "description": null
   },
   "SHUFFLING": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:505",
+    "definedIn": "src/ui/queue.rs:502",
     "plural": false,
     "description": null
   },
@@ -1099,13 +1099,13 @@
   },
   "STOP_REPEATING": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:598",
+    "definedIn": "src/ui/controls.rs:599",
     "plural": false,
     "description": null
   },
   "STOP_SHUFFLING": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:470",
+    "definedIn": "src/ui/controls.rs:471",
     "plural": false,
     "description": null
   },
@@ -1141,13 +1141,13 @@
   },
   "TRACK_DISC": {
     "context": "track_item.rs",
-    "definedIn": "src/ui/library/track_listing/track_item.rs:235",
+    "definedIn": "src/ui/library/track_listing/track_item.rs:236",
     "plural": false,
     "description": null
   },
   "TRACK_DISC_SUBTITLE": {
     "context": "track_item.rs",
-    "definedIn": "src/ui/library/track_listing/track_item.rs:228",
+    "definedIn": "src/ui/library/track_listing/track_item.rs:229",
     "plural": false,
     "description": null
   },
@@ -1159,25 +1159,25 @@
   },
   "TRACK_SIDE": {
     "context": "track_item.rs",
-    "definedIn": "src/ui/library/track_listing/track_item.rs:219",
+    "definedIn": "src/ui/library/track_listing/track_item.rs:220",
     "plural": false,
     "description": null
   },
   "UNKNOWN_ARTIST": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:346",
+    "definedIn": "src/ui/controls.rs:347",
     "plural": false,
     "description": null
   },
   "UNKNOWN_TRACK": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:332",
+    "definedIn": "src/ui/controls.rs:333",
     "plural": false,
     "description": null
   },
   "UNMUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:893",
+    "definedIn": "src/ui/controls.rs:882",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -247,7 +247,7 @@
   },
   "COLLECTION_SUMMARY_TRACKS": {
     "context": "collection_summary.rs",
-    "definedIn": "src/ui/library/collection_summary.rs:7",
+    "definedIn": "src/ui/library/collection_summary.rs:6",
     "plural": true,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -253,61 +253,61 @@
   },
   "COLUMN_ALBUM": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:303",
+    "definedIn": "src/library/types/table.rs:304",
     "plural": false,
     "description": null
   },
   "COLUMN_ALBUMS": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:533",
+    "definedIn": "src/library/types/table.rs:530",
     "plural": false,
     "description": null
   },
   "COLUMN_ARTIST": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:82",
+    "definedIn": "src/library/types/table.rs:83",
     "plural": false,
     "description": null
   },
   "COLUMN_CATALOG_NUMBER": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:85",
+    "definedIn": "src/library/types/table.rs:86",
     "plural": false,
     "description": null
   },
   "COLUMN_DATE": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:83",
+    "definedIn": "src/library/types/table.rs:84",
     "plural": false,
     "description": null
   },
   "COLUMN_LABEL": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:84",
+    "definedIn": "src/library/types/table.rs:85",
     "plural": false,
     "description": null
   },
   "COLUMN_LENGTH": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:305",
+    "definedIn": "src/library/types/table.rs:306",
     "plural": false,
     "description": null
   },
   "COLUMN_NAME": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:532",
+    "definedIn": "src/library/types/table.rs:529",
     "plural": false,
     "description": null
   },
   "COLUMN_TITLE": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:81",
+    "definedIn": "src/library/types/table.rs:82",
     "plural": false,
     "description": null
   },
   "COLUMN_TRACKS": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:534",
+    "definedIn": "src/library/types/table.rs:531",
     "plural": false,
     "description": null
   },
@@ -1111,19 +1111,19 @@
   },
   "TABLE_ALBUMS": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:109",
+    "definedIn": "src/library/types/table.rs:110",
     "plural": false,
     "description": null
   },
   "TABLE_ARTISTS": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:556",
+    "definedIn": "src/library/types/table.rs:553",
     "plural": false,
     "description": null
   },
   "TABLE_TRACKS": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:329",
+    "definedIn": "src/library/types/table.rs:330",
     "plural": false,
     "description": null
   },
@@ -1153,7 +1153,7 @@
   },
   "TRACK_NUMBER": {
     "context": "table.rs",
-    "definedIn": "src/library/types/table.rs:301",
+    "definedIn": "src/library/types/table.rs:302",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -553,13 +553,13 @@
   },
   "LYRICS": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:954",
+    "definedIn": "src/ui/controls.rs:964",
     "plural": false,
     "description": null
   },
   "MUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:889",
+    "definedIn": "src/ui/controls.rs:899",
     "plural": false,
     "description": null
   },
@@ -1177,7 +1177,7 @@
   },
   "UNMUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:882",
+    "definedIn": "src/ui/controls.rs:892",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -97,7 +97,7 @@
   },
   "ACTION_GROUP_PLAYLIST": {
     "context": "library.rs",
-    "definedIn": "src/ui/library.rs:485",
+    "definedIn": "src/ui/library.rs:486",
     "plural": false,
     "description": null
   },
@@ -109,7 +109,7 @@
   },
   "ACTION_IMPORT_PLAYLIST": {
     "context": "library.rs",
-    "definedIn": "src/ui/library.rs:486",
+    "definedIn": "src/ui/library.rs:487",
     "plural": false,
     "description": null
   },
@@ -245,6 +245,12 @@
     "plural": false,
     "description": null
   },
+  "COLLECTION_SUMMARY_TRACKS": {
+    "context": "collection_summary.rs",
+    "definedIn": "src/ui/library/collection_summary.rs:8",
+    "plural": true,
+    "description": null
+  },
   "COLUMN_ALBUM": {
     "context": "table.rs",
     "definedIn": "src/library/types/table.rs:303",
@@ -361,7 +367,7 @@
   },
   "EXPORT_PLAYLIST_TO_M3U": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:242",
+    "definedIn": "src/ui/library/playlist_view.rs:244",
     "plural": false,
     "description": null
   },
@@ -685,13 +691,13 @@
   },
   "RELEASED_DATE": {
     "context": "release_view.rs",
-    "definedIn": "src/ui/library/release_view.rs:254",
+    "definedIn": "src/ui/library/release_view.rs:268",
     "plural": false,
     "description": null
   },
   "RELEASED_YEAR": {
     "context": "release_view.rs",
-    "definedIn": "src/ui/library/release_view.rs:269",
+    "definedIn": "src/ui/library/release_view.rs:283",
     "plural": false,
     "description": null
   },
@@ -1021,13 +1027,13 @@
   },
   "SORT_ALBUM": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:68",
+    "definedIn": "src/ui/library/playlist_view.rs:69",
     "plural": false,
     "description": null
   },
   "SORT_ARTIST": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:65",
+    "definedIn": "src/ui/library/playlist_view.rs:66",
     "plural": false,
     "description": null
   },
@@ -1039,7 +1045,7 @@
   },
   "SORT_CUSTOM": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:60",
+    "definedIn": "src/ui/library/playlist_view.rs:61",
     "plural": false,
     "description": null
   },
@@ -1051,7 +1057,7 @@
   },
   "SORT_DURATION": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:71",
+    "definedIn": "src/ui/library/playlist_view.rs:72",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -247,7 +247,7 @@
   },
   "COLLECTION_SUMMARY_TRACKS": {
     "context": "collection_summary.rs",
-    "definedIn": "src/ui/library/collection_summary.rs:8",
+    "definedIn": "src/ui/library/collection_summary.rs:7",
     "plural": true,
     "description": null
   },


### PR DESCRIPTION
## Summary
Closes #232 
Added tracks label too cause that's where it goes idk, also considered renaming `PlaylistWithCount` since it now carries more than just a count but I'm afraid William will billiam all over my villiam
fuck you victor

## Changes
<img width="386" height="194" alt="image" src="https://github.com/user-attachments/assets/f8d770c1-b220-4b88-92c3-e7f2ea1136fd" />
<img width="412" height="223" alt="image" src="https://github.com/user-attachments/assets/f700fffe-bcb6-499c-aa6f-937ff6b68859" />


## Testing
I sawr em

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
cargo fmt slimed out like 3 files but we good i think
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [x] Documentation added/updated where needed
- [x] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
