### PR TITLE
feat: add website and discord links to the about modal

### DIFF
--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -118,7 +118,7 @@ impl RenderOnce for AboutDialog {
                                                 link_color,
                                                 tr!("ABOUT_COMMUNITY_WEBSITE", "Visit our website"),
                                             ))
-                                            .child(tr!("ABOUT_LINKS_MIDDLE", " or "))
+                                            .child(tr!("ABOUT_LINKS_MIDDLE"))
                                             .child(link_label(
                                                 "about-discord-link",
                                                 DISCORD_URL,

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -118,7 +118,7 @@ impl RenderOnce for AboutDialog {
                                                 link_color,
                                                 tr!("ABOUT_COMMUNITY_WEBSITE", "Visit our website"),
                                             ))
-                                            .child(tr!("ABOUT_LINKS_MIDDLE"))
+                                            .child(tr!("ABOUT_COMMUNITY_MIDDLE", " or "))
                                             .child(link_label(
                                                 "about-discord-link",
                                                 DISCORD_URL,

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -11,7 +11,24 @@ use super::{
 
 const ISSUES_URL: &str = "https://github.com/143mailliw/hummingbird/issues";
 const SOURCE_URL: &str = "https://github.com/143mailliw/hummingbird";
+const WEBSITE_URL: &str = "https://hummingbird.mailliw.org/";
+const DISCORD_URL: &str = "https://discord.gg/6tayc2vzs9";
 const LICENSE_URL: &str = "https://choosealicense.com/licenses/apache-2.0/";
+
+fn link_label(
+    id: impl Into<gpui::ElementId>,
+    url: &'static str,
+    link_color: gpui::Rgba,
+    child: impl IntoElement,
+) -> gpui::Stateful<gpui::Div> {
+    div()
+        .id(id)
+        .cursor_pointer()
+        .text_color(link_color)
+        .hover(move |this| this.border_b_1().border_color(link_color))
+        .on_click(move |_, _, cx| cx.open_url(url))
+        .child(child)
+}
 
 #[derive(IntoElement)]
 pub struct AboutDialog {
@@ -23,6 +40,7 @@ impl RenderOnce for AboutDialog {
     fn render(self, window: &mut gpui::Window, cx: &mut gpui::App) -> impl gpui::IntoElement {
         self.focus_handle.focus(window, cx);
         let theme = cx.global::<Theme>();
+        let link_color = theme.text_link;
 
         modal().on_exit(self.on_exit).child(
             div()
@@ -75,41 +93,44 @@ impl RenderOnce for AboutDialog {
                                                     text. Use a zero-width space (U+200B) if a \
                                                     part isn't needed."
                                             ))
-                                            .child(
-                                                div()
-                                                    .id("about-bug-link")
-                                                    .cursor_pointer()
-                                                    .text_color(theme.text_link)
-                                                    .hover(|this| {
-                                                        this.border_b_1()
-                                                            .border_color(theme.text_link)
-                                                    })
-                                                    .on_click(|_, _, cx| {
-                                                        cx.open_url(ISSUES_URL);
-                                                    })
-                                                    .child(tr!("ABOUT_LINKS_BUG", "Report a bug")),
-                                            )
+                                            .child(link_label(
+                                                "about-bug-link",
+                                                ISSUES_URL,
+                                                link_color,
+                                                tr!("ABOUT_LINKS_BUG", "Report a bug"),
+                                            ))
                                             .child(tr!("ABOUT_LINKS_MIDDLE", " or "))
-                                            .child(
-                                                div()
-                                                    .id("about-source-link")
-                                                    .cursor_pointer()
-                                                    .text_color(theme.text_link)
-                                                    .hover(|this| {
-                                                        this.border_b_1()
-                                                            .border_color(theme.text_link)
-                                                    })
-                                                    .on_click(|_, _, cx| {
-                                                        cx.open_url(SOURCE_URL);
-                                                    })
-                                                    .child(tr!(
-                                                        "ABOUT_LINKS_CODE",
-                                                        "view the source code"
-                                                    )),
-                                            )
+                                            .child(link_label(
+                                                "about-source-link",
+                                                SOURCE_URL,
+                                                link_color,
+                                                tr!("ABOUT_LINKS_CODE", "view the source code"),
+                                            ))
                                             .child(tr!("ABOUT_LINKS_END", " on GitHub.")),
                                     )
-                                    .child(div().child(tr!(
+                                    .child(
+                                        div()
+                                            .flex()
+                                            .child(tr!("ABOUT_COMMUNITY_BEFORE_LINKS", "\u{200B}"))
+                                            .child(link_label(
+                                                "about-website-link",
+                                                WEBSITE_URL,
+                                                link_color,
+                                                tr!("ABOUT_COMMUNITY_WEBSITE", "Visit our website"),
+                                            ))
+                                            .child(tr!("ABOUT_LINKS_MIDDLE", " or "))
+                                            .child(link_label(
+                                                "about-discord-link",
+                                                DISCORD_URL,
+                                                link_color,
+                                                tr!(
+                                                    "ABOUT_COMMUNITY_DISCORD",
+                                                    "join us on Discord"
+                                                ),
+                                            ))
+                                            .child(tr!("ABOUT_COMMUNITY_END", ".")),
+                                    )
+                                    .child(div().mt(px(10.0)).child(tr!(
                                         "ABOUT_COPYRIGHT",
                                         "Copyright © 2024 - 2026 William \
                                             Whittaker and contributors."
@@ -121,23 +142,15 @@ impl RenderOnce for AboutDialog {
                                                 "ABOUT_LICENSE_BEFORE_LINK",
                                                 "Licensed under the Apache License, version 2.0. "
                                             ))
-                                            .child(
-                                                div()
-                                                    .id("about-rights-link")
-                                                    .cursor_pointer()
-                                                    .text_color(theme.text_link)
-                                                    .hover(|this| {
-                                                        this.border_b_1()
-                                                            .border_color(theme.text_link)
-                                                    })
-                                                    .on_click(|_, _, cx| {
-                                                        cx.open_url(LICENSE_URL);
-                                                    })
-                                                    .child(tr!(
-                                                        "ABOUT_LICENSE_LINK",
-                                                        "Learn more about your rights."
-                                                    )),
-                                            )
+                                            .child(link_label(
+                                                "about-rights-link",
+                                                LICENSE_URL,
+                                                link_color,
+                                                tr!(
+                                                    "ABOUT_LICENSE_LINK",
+                                                    "Learn more about your rights."
+                                                ),
+                                            ))
                                             .child(tr!("ABOUT_LICENSE_AFTER_LINK", "\u{200B}")),
                                     ),
                             ),

--- a/translations/en.json
+++ b/translations/en.json
@@ -3,6 +3,7 @@
   "ABOUT_COMMUNITY_BEFORE_LINKS": "​",
   "ABOUT_COMMUNITY_DISCORD": "join us on Discord",
   "ABOUT_COMMUNITY_END": ".",
+  "ABOUT_COMMUNITY_MIDDLE": " or ",
   "ABOUT_COMMUNITY_WEBSITE": "Visit our website",
   "ABOUT_COPYRIGHT": "Copyright © 2024 - 2026 William Whittaker and contributors.",
   "ABOUT_LICENSE_AFTER_LINK": "​",

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,5 +1,9 @@
 {
   "ABOUT": "About Hummingbird",
+  "ABOUT_COMMUNITY_BEFORE_LINKS": "​",
+  "ABOUT_COMMUNITY_DISCORD": "join us on Discord",
+  "ABOUT_COMMUNITY_END": ".",
+  "ABOUT_COMMUNITY_WEBSITE": "Visit our website",
   "ABOUT_COPYRIGHT": "Copyright © 2024 - 2026 William Whittaker and contributors.",
   "ABOUT_LICENSE_AFTER_LINK": "​",
   "ABOUT_LICENSE_BEFORE_LINK": "Licensed under the Apache License, version 2.0. ",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -23,6 +23,12 @@
     "plural": false,
     "description": null
   },
+  "ABOUT_COMMUNITY_MIDDLE": {
+    "context": "about.rs",
+    "definedIn": "src/ui/about.rs:121",
+    "plural": false,
+    "description": null
+  },
   "ABOUT_COMMUNITY_WEBSITE": {
     "context": "about.rs",
     "definedIn": "src/ui/about.rs:119",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -73,7 +73,7 @@
   },
   "ABOUT_LINKS_MIDDLE": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:121",
+    "definedIn": "src/ui/about.rs:102",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -5,57 +5,81 @@
     "plural": false,
     "description": null
   },
+  "ABOUT_COMMUNITY_BEFORE_LINKS": {
+    "context": "about.rs",
+    "definedIn": "src/ui/about.rs:114",
+    "plural": false,
+    "description": null
+  },
+  "ABOUT_COMMUNITY_DISCORD": {
+    "context": "about.rs",
+    "definedIn": "src/ui/about.rs:127",
+    "plural": false,
+    "description": null
+  },
+  "ABOUT_COMMUNITY_END": {
+    "context": "about.rs",
+    "definedIn": "src/ui/about.rs:131",
+    "plural": false,
+    "description": null
+  },
+  "ABOUT_COMMUNITY_WEBSITE": {
+    "context": "about.rs",
+    "definedIn": "src/ui/about.rs:119",
+    "plural": false,
+    "description": null
+  },
   "ABOUT_COPYRIGHT": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:113",
+    "definedIn": "src/ui/about.rs:134",
     "plural": false,
     "description": null
   },
   "ABOUT_LICENSE_AFTER_LINK": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:141",
+    "definedIn": "src/ui/about.rs:154",
     "plural": false,
     "description": null
   },
   "ABOUT_LICENSE_BEFORE_LINK": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:121",
+    "definedIn": "src/ui/about.rs:142",
     "plural": false,
     "description": null
   },
   "ABOUT_LICENSE_LINK": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:137",
+    "definedIn": "src/ui/about.rs:150",
     "plural": false,
     "description": null
   },
   "ABOUT_LINKS_BUG": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:90",
+    "definedIn": "src/ui/about.rs:100",
     "plural": false,
     "description": null
   },
   "ABOUT_LINKS_CODE": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:106",
+    "definedIn": "src/ui/about.rs:107",
     "plural": false,
     "description": null
   },
   "ABOUT_LINKS_END": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:110",
+    "definedIn": "src/ui/about.rs:109",
     "plural": false,
     "description": null
   },
   "ABOUT_LINKS_MIDDLE": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:92",
+    "definedIn": "src/ui/about.rs:121",
     "plural": false,
     "description": null
   },
   "ABOUT_LINKS_START": {
     "context": "about.rs",
-    "definedIn": "src/ui/about.rs:70",
+    "definedIn": "src/ui/about.rs:88",
     "plural": false,
     "description": "Because the UI framework we use doesn't support inline elements, we have to use a seperate string for each part of this text. Use a zero-width space (U+200B) if a part isn't needed."
   },


### PR DESCRIPTION
## Summary
more information

## Changes
adds an about modal specific invite (mainly to see how many beings use this) and made a helper function for links. i think if more link-labels get added this should be extracted out, but for now it's just localized to the modal

## Testing
<!-- How did you test these changes? -->

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
