### PR TITLE
fix: prevent command palette from opening with an open modal

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,6 +1,9 @@
 use std::{
     fs,
-    sync::{Arc, RwLock},
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use cntp_i18n::{I18N_MANAGER, Locale, tr};
@@ -38,7 +41,12 @@ use crate::{
 use super::{
     about::about_dialog,
     arguments::parse_args_and_prepare,
-    components::{input, modal, popover, window_chrome::window_chrome},
+    components::{
+        input,
+        modal::{self, ModalActive},
+        popover,
+        window_chrome::window_chrome,
+    },
     controls::Controls,
     global_actions::register_actions,
     header::Header,
@@ -67,6 +75,8 @@ struct WindowShadow {
 
 impl Render for WindowShadow {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        cx.global::<ModalActive>().0.store(false, Ordering::Relaxed);
+
         let right_sidebar = self.right_sidebar.clone();
         let show_about = *self.show_about.clone().read(cx);
         let scan_state = cx.global::<Models>().scan_state.read(cx).clone();
@@ -233,6 +243,8 @@ pub fn run() -> anyhow::Result<()> {
             library::bind_actions(cx);
             dropdown::bind_actions(cx);
             popover::bind_actions(cx);
+
+            cx.set_global(modal::ModalActive(AtomicBool::new(false)));
 
             let settings_model = cx.global::<SettingsGlobal>().model.clone();
             cx.observe(&settings_model, |_, cx| cx.refresh_windows())

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, atomic::Ordering};
 
 use cntp_i18n::tr;
 use gpui::{
@@ -10,6 +10,7 @@ use rustc_hash::FxHashMap;
 use std::hash::Hash;
 use tracing::error;
 
+use crate::ui::components::modal::ModalActive;
 #[cfg(feature = "update")]
 use crate::ui::global_actions::CheckForUpdates;
 use crate::ui::{
@@ -276,6 +277,10 @@ impl CommandPalette {
             let weak_self = cx.weak_entity();
             let show_clone = show.clone();
             App::on_action(cx, move |_: &OpenPalette, cx: &mut App| {
+                if cx.global::<ModalActive>().0.load(Ordering::Relaxed) {
+                    return;
+                }
+
                 show_clone.update(cx, |show, cx| {
                     *show = true;
                     cx.notify();

--- a/src/ui/components/modal.rs
+++ b/src/ui/components/modal.rs
@@ -1,4 +1,5 @@
 use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use gpui::*;
 use prelude::FluentBuilder;
@@ -7,6 +8,9 @@ use crate::ui::{
     constants::{APP_ROUNDING, APP_SHADOW_SIZE},
     theme::Theme,
 };
+
+pub struct ModalActive(pub AtomicBool);
+impl Global for ModalActive {}
 
 pub type OnExitHandler = dyn Fn(&mut Window, &mut App);
 
@@ -44,6 +48,8 @@ impl ParentElement for Modal {
 
 impl RenderOnce for Modal {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        cx.global::<ModalActive>().0.store(true, Ordering::Relaxed);
+
         let decorations = window.window_decorations();
         let theme = cx.global::<Theme>();
         let mut size = window.viewport_size();

--- a/src/ui/library/sidebar/playlists.rs
+++ b/src/ui/library/sidebar/playlists.rs
@@ -12,7 +12,7 @@ use crate::{
     library::{
         db::LibraryAccess,
         playlist::export_playlist,
-        types::{PlaylistType, Playlist},
+        types::{Playlist, PlaylistType},
     },
     playback::interface::PlaybackInterface,
     settings::SettingsGlobal,

--- a/src/ui/library/update_playlist.rs
+++ b/src/ui/library/update_playlist.rs
@@ -11,7 +11,7 @@ use crate::{
     library::{
         db::LibraryAccess,
         playlist::import_playlist,
-        types::{PlaylistType, Playlist},
+        types::{Playlist, PlaylistType},
     },
     ui::components::{
         icons::{PLAYLIST, PLAYLIST_ADD, STAR_FILLED},

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -1,8 +1,10 @@
 pub mod model;
 pub mod search_item;
 
+use crate::ui::components::modal::ModalActive;
 use gpui::*;
 use model::SearchModel;
+use std::sync::atomic::Ordering;
 
 use super::{
     components::modal::modal,
@@ -25,6 +27,10 @@ impl SearchView {
             let search = SearchModel::new(cx, &show);
 
             App::on_action(cx, move |_: &Search, cx| {
+                if cx.global::<ModalActive>().0.load(Ordering::Relaxed) {
+                    return;
+                }
+
                 show_clone.update(cx, |m, cx| {
                     *m = true;
                     cx.notify();

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -61,37 +61,37 @@
   },
   "ACTION_ABOUT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:165",
+    "definedIn": "src/ui/command_palette.rs:166",
     "plural": false,
     "description": null
   },
   "ACTION_CHECK_FOR_UPDATES": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:193",
+    "definedIn": "src/ui/command_palette.rs:194",
     "plural": false,
     "description": null
   },
   "ACTION_COPY_TROUBLESHOOTING_INFO": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:212",
+    "definedIn": "src/ui/command_palette.rs:213",
     "plural": false,
     "description": null
   },
   "ACTION_FORCESCAN": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:252",
+    "definedIn": "src/ui/command_palette.rs:253",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_HUMMINGBIRD": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:155",
+    "definedIn": "src/ui/command_palette.rs:156",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_PLAYBACK": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:223",
+    "definedIn": "src/ui/command_palette.rs:224",
     "plural": false,
     "description": null
   },
@@ -103,7 +103,7 @@
   },
   "ACTION_GROUP_SCAN": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:251",
+    "definedIn": "src/ui/command_palette.rs:252",
     "plural": false,
     "description": null
   },
@@ -115,49 +115,49 @@
   },
   "ACTION_NEXT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:233",
+    "definedIn": "src/ui/command_palette.rs:234",
     "plural": false,
     "description": null
   },
   "ACTION_OPEN_LOG": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:202",
+    "definedIn": "src/ui/command_palette.rs:203",
     "plural": false,
     "description": null
   },
   "ACTION_PLAYPAUSE": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:224",
+    "definedIn": "src/ui/command_palette.rs:225",
     "plural": false,
     "description": null
   },
   "ACTION_PREVIOUS": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:242",
+    "definedIn": "src/ui/command_palette.rs:243",
     "plural": false,
     "description": null
   },
   "ACTION_QUIT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:156",
+    "definedIn": "src/ui/command_palette.rs:157",
     "plural": false,
     "description": null
   },
   "ACTION_SEARCH": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:174",
+    "definedIn": "src/ui/command_palette.rs:175",
     "plural": false,
     "description": null
   },
   "ACTION_SETTINGS": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:183",
+    "definedIn": "src/ui/command_palette.rs:184",
     "plural": false,
     "description": null
   },
   "ACTION_SHUFFLE_ALL": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:262",
+    "definedIn": "src/ui/command_palette.rs:263",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
noticed this when working on #287 but you could open the command palette in the background with the about modal open (among others.) fixes that and fmts unformatted files (UGH)

## Changes
adds a `ModalActive` global

## Testing
<!-- How did you test these changes? -->

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
