### PR TITLE
feat: add reduced motion setting

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -280,6 +280,7 @@ mod tests {
                 "interface": {
                     "theme": "custom.json",
                     "full_width_library": true,
+                    "reduced_motion": true,
                     "always_show_scrollbars": true
                 },
                 "update": {
@@ -298,6 +299,7 @@ mod tests {
         assert!(!settings.playback.keep_current_on_queue_clear);
         assert_eq!(settings.interface.theme.as_deref(), Some("custom.json"));
         assert!(settings.interface.full_width_library);
+        assert!(settings.interface.reduced_motion);
         assert!(settings.interface.always_show_scrollbars);
         assert_eq!(
             settings.update.release_channel,

--- a/src/settings/interface.rs
+++ b/src/settings/interface.rs
@@ -41,6 +41,8 @@ pub struct InterfaceSettings {
     #[serde(default = "default_grid_min_item_width")]
     pub grid_min_item_width: f32,
     #[serde(default)]
+    pub reduced_motion: bool,
+    #[serde(default)]
     pub always_show_scrollbars: bool,
 }
 
@@ -63,6 +65,7 @@ impl Default for InterfaceSettings {
             two_column_library: false,
             startup_library_view: StartupLibraryView::default(),
             grid_min_item_width: DEFAULT_GRID_MIN_ITEM_WIDTH,
+            reduced_motion: false,
             always_show_scrollbars: false,
         }
     }

--- a/src/ui/components/drag_drop.rs
+++ b/src/ui/components/drag_drop.rs
@@ -392,12 +392,7 @@ pub fn perform_edge_scroll(
     scroll_handle: &ScrollableHandle,
     direction: EdgeScrollDirection,
     config: &EdgeScrollConfig,
-    reduced_motion: bool,
 ) -> bool {
-    if reduced_motion {
-        return false;
-    }
-
     match direction {
         // remember GPUI scroll offsets are negative
         EdgeScrollDirection::Up => {
@@ -456,12 +451,11 @@ pub fn handle_drag_move<V: 'static>(
     });
 
     let direction = get_edge_scroll_direction(mouse_pos.y, container_bounds, &config.scroll_config);
-    let scrolled = perform_edge_scroll(
-        &scroll_handle,
-        direction,
-        &config.scroll_config,
-        reduced_motion,
-    );
+    let scrolled = if reduced_motion {
+        false
+    } else {
+        perform_edge_scroll(&scroll_handle, direction, &config.scroll_config)
+    };
 
     if !container_bounds.contains(&mouse_pos) {
         manager.update(cx, |m, _| m.state.clear_drop_target());
@@ -528,12 +522,11 @@ pub fn handle_track_drag_move<V: 'static>(
     });
 
     let direction = get_edge_scroll_direction(mouse_pos.y, container_bounds, &config.scroll_config);
-    let scrolled = perform_edge_scroll(
-        &scroll_handle,
-        direction,
-        &config.scroll_config,
-        reduced_motion,
-    );
+    let scrolled = if reduced_motion {
+        false
+    } else {
+        perform_edge_scroll(&scroll_handle, direction, &config.scroll_config)
+    };
 
     if !container_bounds.contains(&mouse_pos) {
         manager.update(cx, |m, _| m.state.clear_drop_target());
@@ -654,12 +647,7 @@ pub fn check_drag_cancelled<V: 'static>(
 pub fn continue_edge_scroll(
     manager: &DragDropListManager,
     scroll_handle: &ScrollableHandle,
-    reduced_motion: bool,
 ) -> bool {
-    if reduced_motion {
-        return false;
-    }
-
     if !manager.state.is_dragging {
         return false;
     }
@@ -673,10 +661,5 @@ pub fn continue_edge_scroll(
     };
 
     let direction = get_edge_scroll_direction(mouse_y, bounds, &manager.config.scroll_config);
-    perform_edge_scroll(
-        scroll_handle,
-        direction,
-        &manager.config.scroll_config,
-        reduced_motion,
-    )
+    perform_edge_scroll(scroll_handle, direction, &manager.config.scroll_config)
 }

--- a/src/ui/components/drag_drop.rs
+++ b/src/ui/components/drag_drop.rs
@@ -392,7 +392,12 @@ pub fn perform_edge_scroll(
     scroll_handle: &ScrollableHandle,
     direction: EdgeScrollDirection,
     config: &EdgeScrollConfig,
+    reduced_motion: bool,
 ) -> bool {
+    if reduced_motion {
+        return false;
+    }
+
     match direction {
         // remember GPUI scroll offsets are negative
         EdgeScrollDirection::Up => {
@@ -430,6 +435,7 @@ pub fn handle_drag_move<V: 'static>(
     event: &DragMoveEvent<DragData>,
     item_count: usize,
     cx: &mut Context<V>,
+    reduced_motion: bool,
 ) -> bool {
     let drag_data = event.drag(cx);
     let config = manager.read(cx).config.clone();
@@ -450,7 +456,12 @@ pub fn handle_drag_move<V: 'static>(
     });
 
     let direction = get_edge_scroll_direction(mouse_pos.y, container_bounds, &config.scroll_config);
-    let scrolled = perform_edge_scroll(&scroll_handle, direction, &config.scroll_config);
+    let scrolled = perform_edge_scroll(
+        &scroll_handle,
+        direction,
+        &config.scroll_config,
+        reduced_motion,
+    );
 
     if !container_bounds.contains(&mouse_pos) {
         manager.update(cx, |m, _| m.state.clear_drop_target());
@@ -487,6 +498,7 @@ pub fn handle_track_drag_move<V: 'static>(
     event: &DragMoveEvent<TrackDragData>,
     item_count: usize,
     cx: &mut Context<V>,
+    reduced_motion: bool,
 ) -> bool {
     let drag_data = event.drag(cx);
     let config = manager.read(cx).config.clone();
@@ -516,7 +528,12 @@ pub fn handle_track_drag_move<V: 'static>(
     });
 
     let direction = get_edge_scroll_direction(mouse_pos.y, container_bounds, &config.scroll_config);
-    let scrolled = perform_edge_scroll(&scroll_handle, direction, &config.scroll_config);
+    let scrolled = perform_edge_scroll(
+        &scroll_handle,
+        direction,
+        &config.scroll_config,
+        reduced_motion,
+    );
 
     if !container_bounds.contains(&mouse_pos) {
         manager.update(cx, |m, _| m.state.clear_drop_target());
@@ -637,7 +654,12 @@ pub fn check_drag_cancelled<V: 'static>(
 pub fn continue_edge_scroll(
     manager: &DragDropListManager,
     scroll_handle: &ScrollableHandle,
+    reduced_motion: bool,
 ) -> bool {
+    if reduced_motion {
+        return false;
+    }
+
     if !manager.state.is_dragging {
         return false;
     }
@@ -651,5 +673,10 @@ pub fn continue_edge_scroll(
     };
 
     let direction = get_edge_scroll_direction(mouse_y, bounds, &manager.config.scroll_config);
-    perform_edge_scroll(scroll_handle, direction, &manager.config.scroll_config)
+    perform_edge_scroll(
+        scroll_handle,
+        direction,
+        &manager.config.scroll_config,
+        reduced_motion,
+    )
 }

--- a/src/ui/components/scrollbar.rs
+++ b/src/ui/components/scrollbar.rs
@@ -273,7 +273,8 @@ impl Element for Scrollbar {
         let fade_duration = self.fade_duration;
         let always_visible = {
             let settings = cx.global::<SettingsGlobal>();
-            settings.model.read(cx).interface.always_show_scrollbars
+            let settings = settings.model.read(cx);
+            settings.interface.always_show_scrollbars || settings.interface.reduced_motion
         };
 
         window.with_optional_element_state(

--- a/src/ui/library/playlist_view.rs
+++ b/src/ui/library/playlist_view.rs
@@ -407,7 +407,14 @@ impl PlaylistView {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let should_continue = continue_edge_scroll(manager.read(cx), &scroll_handle);
+        let reduced_motion = cx
+            .global::<crate::settings::SettingsGlobal>()
+            .model
+            .read(cx)
+            .interface
+            .reduced_motion;
+        let should_continue =
+            continue_edge_scroll(manager.read(cx), &scroll_handle, reduced_motion);
 
         if should_continue {
             let manager_clone = manager.clone();
@@ -653,12 +660,19 @@ impl Render for PlaylistView {
                                         let scroll_handle: ScrollableHandle =
                                             this.scroll_handle.clone().into();
 
+                                        let reduced_motion = cx
+                                            .global::<crate::settings::SettingsGlobal>()
+                                            .model
+                                            .read(cx)
+                                            .interface
+                                            .reduced_motion;
                                         let scrolled = handle_track_drag_move(
                                             this.drag_drop_manager.clone(),
                                             scroll_handle,
                                             event,
                                             item_count,
                                             cx,
+                                            reduced_motion,
                                         );
 
                                         if scrolled {

--- a/src/ui/library/playlist_view.rs
+++ b/src/ui/library/playlist_view.rs
@@ -413,8 +413,11 @@ impl PlaylistView {
             .read(cx)
             .interface
             .reduced_motion;
-        let should_continue =
-            continue_edge_scroll(manager.read(cx), &scroll_handle, reduced_motion);
+        if reduced_motion {
+            return;
+        }
+
+        let should_continue = continue_edge_scroll(manager.read(cx), &scroll_handle);
 
         if should_continue {
             let manager_clone = manager.clone();

--- a/src/ui/library/release_view.rs
+++ b/src/ui/library/release_view.rs
@@ -306,11 +306,22 @@ impl ReleaseView {
         self.scroll_frame_scheduled = true;
         cx.on_next_frame(window, |this, window, cx| {
             this.scroll_frame_scheduled = false;
-            this.advance_scroll_animation(window, cx);
+            let reduced_motion = cx
+                .global::<crate::settings::SettingsGlobal>()
+                .model
+                .read(cx)
+                .interface
+                .reduced_motion;
+            this.advance_scroll_animation(window, cx, reduced_motion);
         });
     }
 
-    fn advance_scroll_animation(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn advance_scroll_animation(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+        reduced_motion: bool,
+    ) {
         if let Some(pending_scroll) = self.pending_scroll {
             match self.compute_follow_target(pending_scroll) {
                 FollowTarget::PendingLayout => {
@@ -322,14 +333,26 @@ impl ReleaseView {
                 }
                 FollowTarget::Target(target_scroll_top) => {
                     let scroll_handle: ScrollableHandle = self.scroll_handle.clone().into();
-                    self.scroll_follow
-                        .animate_to(&scroll_handle, target_scroll_top);
+                    if reduced_motion {
+                        self.scroll_follow
+                            .jump_to(&scroll_handle, target_scroll_top);
+                    } else {
+                        self.scroll_follow
+                            .animate_to(&scroll_handle, target_scroll_top);
+                    }
                     self.pending_scroll = None;
                 }
             }
         }
 
         let scroll_handle: ScrollableHandle = self.scroll_handle.clone().into();
+        if reduced_motion {
+            if self.scroll_follow.snap(&scroll_handle) {
+                cx.notify();
+            }
+            return;
+        }
+
         let changed = self.scroll_follow.advance(&scroll_handle);
 
         if self.scroll_follow.is_active() {
@@ -373,8 +396,17 @@ enum FollowTarget {
 
 impl Render for ReleaseView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let settings = cx
+            .global::<crate::settings::SettingsGlobal>()
+            .model
+            .read(cx);
+        let reduced_motion = settings.interface.reduced_motion;
         if self.pending_scroll.is_some() || self.scroll_follow.is_active() {
-            self.schedule_scroll_frame(window, cx);
+            if reduced_motion {
+                self.advance_scroll_animation(window, cx, reduced_motion);
+            } else {
+                self.schedule_scroll_frame(window, cx);
+            }
         }
 
         let theme = cx.global::<Theme>();

--- a/src/ui/library/release_view.rs
+++ b/src/ui/library/release_view.rs
@@ -403,6 +403,9 @@ impl Render for ReleaseView {
         let reduced_motion = settings.interface.reduced_motion;
         if self.pending_scroll.is_some() || self.scroll_follow.is_active() {
             if reduced_motion {
+                // Reduced motion still needs one pass to resolve pending layout and snap any
+                // in-flight scroll animation to its final position; we just skip scheduling
+                // another animated frame afterward.
                 self.advance_scroll_animation(window, cx, reduced_motion);
             } else {
                 self.schedule_scroll_frame(window, cx);

--- a/src/ui/lyrics.rs
+++ b/src/ui/lyrics.rs
@@ -5,6 +5,7 @@ use lrc::{LrcLine, parse_lrc};
 use crate::{
     library::db::LibraryAccess,
     playback::interface::PlaybackInterface,
+    settings::SettingsGlobal,
     ui::{
         components::{
             icons::{MICROPHONE, icon},
@@ -81,7 +82,13 @@ impl Lyrics {
                     let idx = parsed.partition_point(|l| l.time_ms <= pos_ms);
                     let new_line = if idx == 0 { None } else { Some(idx - 1) };
                     if new_line != this.last_active_line {
-                        this.start_line_emphasis_animation(new_line);
+                        let reduced_motion = cx
+                            .global::<SettingsGlobal>()
+                            .model
+                            .read(cx)
+                            .interface
+                            .reduced_motion;
+                        this.start_line_emphasis_animation(new_line, reduced_motion);
                         this.last_active_line = new_line;
                         this.follow_pending = new_line.is_some();
 
@@ -127,11 +134,22 @@ impl Render for Lyrics {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.global::<Theme>();
         let queue = cx.global::<Models>().queue_width.read(cx).as_f32();
+        let reduced_motion = cx
+            .global::<SettingsGlobal>()
+            .model
+            .read(cx)
+            .interface
+            .reduced_motion;
 
         let muted = theme.text_secondary;
         let normal = theme.text;
 
-        if self.needs_animation_frame() {
+        if reduced_motion {
+            if self.follow_pending || self.scroll_follow.is_active() || self.needs_animation_frame()
+            {
+                self.advance_animations(window, cx, true);
+            }
+        } else if self.needs_animation_frame() {
             self.schedule_follow_frame(window, cx);
         }
 
@@ -276,22 +294,33 @@ impl Lyrics {
         self.follow_frame_scheduled = true;
         cx.on_next_frame(window, |this, window, cx| {
             this.follow_frame_scheduled = false;
-            this.advance_animations(window, cx);
+            let reduced_motion = cx
+                .global::<SettingsGlobal>()
+                .model
+                .read(cx)
+                .interface
+                .reduced_motion;
+            this.advance_animations(window, cx, reduced_motion);
         });
     }
 
-    fn advance_animations(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn advance_animations(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+        reduced_motion: bool,
+    ) {
         let mut changed = false;
 
         if self.has_recent_user_interaction() {
             self.scroll_follow.cancel();
         } else {
-            changed |= self.advance_follow_animation(window, cx);
+            changed |= self.advance_follow_animation(window, cx, reduced_motion);
         }
 
-        changed |= self.advance_line_emphasis_animation();
+        changed |= self.advance_line_emphasis_animation(reduced_motion);
 
-        if self.needs_animation_frame() {
+        if !reduced_motion && self.needs_animation_frame() {
             self.schedule_follow_frame(window, cx);
         }
 
@@ -300,7 +329,12 @@ impl Lyrics {
         }
     }
 
-    fn advance_follow_animation(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+    fn advance_follow_animation(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+        reduced_motion: bool,
+    ) -> bool {
         if self.follow_pending {
             match self.compute_follow_target() {
                 FollowTarget::PendingLayout => {
@@ -313,14 +347,23 @@ impl Lyrics {
                 }
                 FollowTarget::Target(target_scroll_top) => {
                     let scroll_handle: ScrollableHandle = self.scroll_handle.clone().into();
-                    self.scroll_follow
-                        .animate_to(&scroll_handle, target_scroll_top);
+                    if reduced_motion {
+                        self.scroll_follow
+                            .jump_to(&scroll_handle, target_scroll_top);
+                    } else {
+                        self.scroll_follow
+                            .animate_to(&scroll_handle, target_scroll_top);
+                    }
                     self.follow_pending = false;
                 }
             }
         }
 
         let scroll_handle: ScrollableHandle = self.scroll_handle.clone().into();
+        if reduced_motion {
+            return self.scroll_follow.snap(&scroll_handle);
+        }
+
         self.scroll_follow.advance(&scroll_handle)
     }
 
@@ -351,7 +394,7 @@ impl Lyrics {
         }
     }
 
-    fn start_line_emphasis_animation(&mut self, active_line: Option<usize>) {
+    fn start_line_emphasis_animation(&mut self, active_line: Option<usize>, reduced_motion: bool) {
         let line_count = self.parsed.as_ref().map_or(0, Vec::len);
         if self.line_emphasis_target_values.len() != line_count {
             self.line_emphasis_target_values = vec![0.0; line_count];
@@ -374,10 +417,27 @@ impl Lyrics {
             .zip(self.line_emphasis_target_values.iter())
             .any(|(start, target)| (start - target).abs() > f32::EPSILON);
 
-        self.line_emphasis_started_at = has_change.then(Instant::now);
+        if reduced_motion {
+            self.line_emphasis_start_values = self.line_emphasis_target_values.clone();
+            self.line_emphasis_started_at = None;
+        } else {
+            self.line_emphasis_started_at = has_change.then(Instant::now);
+        }
     }
 
-    fn advance_line_emphasis_animation(&mut self) -> bool {
+    fn advance_line_emphasis_animation(&mut self, reduced_motion: bool) -> bool {
+        if reduced_motion {
+            let changed = self
+                .line_emphasis_start_values
+                .iter()
+                .zip(self.line_emphasis_target_values.iter())
+                .any(|(start, target)| (start - target).abs() > f32::EPSILON)
+                || self.line_emphasis_started_at.is_some();
+            self.line_emphasis_start_values = self.line_emphasis_target_values.clone();
+            self.line_emphasis_started_at = None;
+            return changed;
+        }
+
         let Some(started_at) = self.line_emphasis_started_at else {
             return false;
         };

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -433,13 +433,23 @@ impl Render for Queue {
         let scroll_handle = self.scroll_handle.clone();
         let item_scroll_handle = scroll_handle.clone();
         let drag_drop_manager = self.drag_drop_manager.clone();
+        let reduced_motion = cx
+            .global::<SettingsGlobal>()
+            .model
+            .read(cx)
+            .interface
+            .reduced_motion;
         let is_dragging = self.drag_drop_manager.read(cx).state.is_dragging;
 
         if self.scroll_follow.is_active() && (self.queue_hovered || is_dragging) {
             self.scroll_follow.cancel();
         }
 
-        if (self.follow_current_pending || self.scroll_follow.is_active())
+        if reduced_motion {
+            if self.follow_current_pending || self.scroll_follow.is_active() {
+                self.advance_follow_animation(window, cx, reduced_motion);
+            }
+        } else if (self.follow_current_pending || self.scroll_follow.is_active())
             && !self.queue_hovered
             && !is_dragging
         {
@@ -530,12 +540,19 @@ impl Render for Queue {
                         move |this: &mut Queue, event: &DragMoveEvent<DragData>, window, cx| {
                             let scroll_handle: ScrollableHandle = this.scroll_handle.clone().into();
 
+                            let reduced_motion = cx
+                                .global::<SettingsGlobal>()
+                                .model
+                                .read(cx)
+                                .interface
+                                .reduced_motion;
                             let scrolled = handle_drag_move(
                                 this.drag_drop_manager.clone(),
                                 scroll_handle,
                                 event,
                                 queue_len,
                                 cx,
+                                reduced_motion,
                             );
 
                             if scrolled {
@@ -582,10 +599,17 @@ impl Render for Queue {
                                 container_bounds,
                                 &config.scroll_config,
                             );
+                            let reduced_motion = cx
+                                .global::<SettingsGlobal>()
+                                .model
+                                .read(cx)
+                                .interface
+                                .reduced_motion;
                             let scrolled = perform_edge_scroll(
                                 &scroll_handle,
                                 direction,
                                 &config.scroll_config,
+                                reduced_motion,
                             );
 
                             if scrolled {
@@ -654,10 +678,17 @@ impl Render for Queue {
                                 container_bounds,
                                 &config.scroll_config,
                             );
+                            let reduced_motion = cx
+                                .global::<SettingsGlobal>()
+                                .model
+                                .read(cx)
+                                .interface
+                                .reduced_motion;
                             let scrolled = perform_edge_scroll(
                                 &scroll_handle,
                                 direction,
                                 &config.scroll_config,
+                                reduced_motion,
                             );
 
                             if scrolled {
@@ -860,11 +891,22 @@ impl Queue {
         self.follow_frame_scheduled = true;
         cx.on_next_frame(window, |this, window, cx| {
             this.follow_frame_scheduled = false;
-            this.advance_follow_animation(window, cx);
+            let reduced_motion = cx
+                .global::<SettingsGlobal>()
+                .model
+                .read(cx)
+                .interface
+                .reduced_motion;
+            this.advance_follow_animation(window, cx, reduced_motion);
         });
     }
 
-    fn advance_follow_animation(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn advance_follow_animation(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+        reduced_motion: bool,
+    ) {
         if self.queue_hovered || self.drag_drop_manager.read(cx).state.is_dragging {
             self.scroll_follow.cancel();
             return;
@@ -882,14 +924,26 @@ impl Queue {
                 }
                 FollowTarget::Target(target_scroll_top) => {
                     let scroll_handle: ScrollableHandle = self.scroll_handle.clone().into();
-                    self.scroll_follow
-                        .animate_to(&scroll_handle, target_scroll_top);
+                    if reduced_motion {
+                        self.scroll_follow
+                            .jump_to(&scroll_handle, target_scroll_top);
+                    } else {
+                        self.scroll_follow
+                            .animate_to(&scroll_handle, target_scroll_top);
+                    }
                     self.follow_current_pending = false;
                 }
             }
         }
 
         let scroll_handle: ScrollableHandle = self.scroll_handle.clone().into();
+        if reduced_motion {
+            if self.scroll_follow.snap(&scroll_handle) {
+                cx.notify();
+            }
+            return;
+        }
+
         let changed = self.scroll_follow.advance(&scroll_handle);
 
         if !changed {
@@ -948,7 +1002,18 @@ impl Queue {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let should_continue = continue_edge_scroll(manager.read(cx), &scroll_handle);
+        let reduced_motion = cx
+            .global::<SettingsGlobal>()
+            .model
+            .read(cx)
+            .interface
+            .reduced_motion;
+        if reduced_motion {
+            return;
+        }
+
+        let should_continue =
+            continue_edge_scroll(manager.read(cx), &scroll_handle, reduced_motion);
 
         if should_continue {
             let manager_clone = manager.clone();

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -605,12 +605,15 @@ impl Render for Queue {
                                 .read(cx)
                                 .interface
                                 .reduced_motion;
-                            let scrolled = perform_edge_scroll(
-                                &scroll_handle,
-                                direction,
-                                &config.scroll_config,
-                                reduced_motion,
-                            );
+                            let scrolled = if reduced_motion {
+                                false
+                            } else {
+                                perform_edge_scroll(
+                                    &scroll_handle,
+                                    direction,
+                                    &config.scroll_config,
+                                )
+                            };
 
                             if scrolled {
                                 let entity = cx.entity().downgrade();
@@ -684,12 +687,15 @@ impl Render for Queue {
                                 .read(cx)
                                 .interface
                                 .reduced_motion;
-                            let scrolled = perform_edge_scroll(
-                                &scroll_handle,
-                                direction,
-                                &config.scroll_config,
-                                reduced_motion,
-                            );
+                            let scrolled = if reduced_motion {
+                                false
+                            } else {
+                                perform_edge_scroll(
+                                    &scroll_handle,
+                                    direction,
+                                    &config.scroll_config,
+                                )
+                            };
 
                             if scrolled {
                                 let entity = cx.entity().downgrade();
@@ -1012,8 +1018,7 @@ impl Queue {
             return;
         }
 
-        let should_continue =
-            continue_edge_scroll(manager.read(cx), &scroll_handle, reduced_motion);
+        let should_continue = continue_edge_scroll(manager.read(cx), &scroll_handle);
 
         if should_continue {
             let manager_clone = manager.clone();

--- a/src/ui/scroll_follow.rs
+++ b/src/ui/scroll_follow.rs
@@ -26,6 +26,30 @@ impl SmoothScrollFollow {
         self.animation = None;
     }
 
+    pub fn jump_to(&mut self, scroll_handle: &ScrollableHandle, target_scroll_top: Pixels) {
+        self.cancel();
+
+        let current_offset = scroll_handle.offset();
+        scroll_handle.set_offset(gpui::Point {
+            x: current_offset.x,
+            y: -target_scroll_top,
+        });
+    }
+
+    pub fn snap(&mut self, scroll_handle: &ScrollableHandle) -> bool {
+        let Some(animation) = self.animation.as_ref() else {
+            return false;
+        };
+
+        let current_offset = scroll_handle.offset();
+        scroll_handle.set_offset(gpui::Point {
+            x: current_offset.x,
+            y: -animation.target_scroll_top,
+        });
+        self.animation = None;
+        true
+    }
+
     pub fn is_active(&self) -> bool {
         self.animation.is_some()
     }

--- a/src/ui/settings/interface.rs
+++ b/src/ui/settings/interface.rs
@@ -299,6 +299,27 @@ impl Render for InterfaceSettings {
             )
             .child(
                 label(
+                    "interface-reduced-motion",
+                    tr!("INTERFACE_REDUCED_MOTION", "Reduced motion"),
+                )
+                .subtext(tr!(
+                    "INTERFACE_REDUCED_MOTION_SUBTEXT",
+                    "Disables smooth scrolling, fades, and other motion-heavy UI animations."
+                ))
+                .cursor_pointer()
+                .w_full()
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.update_interface(cx, |interface| {
+                        interface.reduced_motion = !interface.reduced_motion;
+                    });
+                }))
+                .child(checkbox(
+                    "interface-reduced-motion-check",
+                    interface.reduced_motion,
+                )),
+            )
+            .child(
+                label(
                     "interface-always-show-scrollbars",
                     tr!("INTERFACE_ALWAYS_SHOW_SCROLLBARS", "Always show scrollbars"),
                 )

--- a/translations/en.json
+++ b/translations/en.json
@@ -85,6 +85,8 @@
   "INTERFACE_FULL_WIDTH_LIBRARY_SUBTEXT": "Allows the library to take up the full width of the screen.",
   "INTERFACE_GRID_MIN_ITEM_WIDTH": "Grid item width",
   "INTERFACE_GRID_MIN_ITEM_WIDTH_SUBTEXT": "Adjusts the minimum width of items in grid view.",
+  "INTERFACE_REDUCED_MOTION": "Reduced motion",
+  "INTERFACE_REDUCED_MOTION_SUBTEXT": "Disables smooth scrolling, fades, and other motion-heavy UI animations.",
   "INTERFACE_STARTUP_LIBRARY_VIEW": "Default startup view",
   "INTERFACE_STARTUP_LIBRARY_VIEW_SUBTEXT": "Choose which library page opens when Hummingbird launches.",
   "INTERFACE_THEME": "Theme",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -253,7 +253,7 @@
   },
   "CLEAR_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:490",
+    "definedIn": "src/ui/queue.rs:500",
     "plural": false,
     "description": null
   },
@@ -265,7 +265,7 @@
   },
   "CLOSE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:475",
+    "definedIn": "src/ui/queue.rs:485",
     "plural": false,
     "description": null
   },
@@ -463,13 +463,13 @@
   },
   "INTERFACE_ALWAYS_SHOW_SCROLLBARS": {
     "context": "interface.rs",
-    "definedIn": "src/ui/settings/interface.rs:303",
+    "definedIn": "src/ui/settings/interface.rs:324",
     "plural": false,
     "description": null
   },
   "INTERFACE_ALWAYS_SHOW_SCROLLBARS_SUBTEXT": {
     "context": "interface.rs",
-    "definedIn": "src/ui/settings/interface.rs:306",
+    "definedIn": "src/ui/settings/interface.rs:327",
     "plural": false,
     "description": null
   },
@@ -494,6 +494,18 @@
   "INTERFACE_GRID_MIN_ITEM_WIDTH_SUBTEXT": {
     "context": "interface.rs",
     "definedIn": "src/ui/settings/interface.rs:277",
+    "plural": false,
+    "description": null
+  },
+  "INTERFACE_REDUCED_MOTION": {
+    "context": "interface.rs",
+    "definedIn": "src/ui/settings/interface.rs:303",
+    "plural": false,
+    "description": null
+  },
+  "INTERFACE_REDUCED_MOTION_SUBTEXT": {
+    "context": "interface.rs",
+    "definedIn": "src/ui/settings/interface.rs:306",
     "plural": false,
     "description": null
   },
@@ -613,7 +625,7 @@
   },
   "NO_LYRICS": {
     "context": "lyrics.rs",
-    "definedIn": "src/ui/lyrics.rs:152",
+    "definedIn": "src/ui/lyrics.rs:170",
     "plural": false,
     "description": null
   },
@@ -715,7 +727,7 @@
   },
   "QUEUE_TITLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:468",
+    "definedIn": "src/ui/queue.rs:478",
     "plural": false,
     "description": null
   },
@@ -1045,13 +1057,13 @@
   },
   "SHUFFLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:503",
+    "definedIn": "src/ui/queue.rs:513",
     "plural": false,
     "description": null
   },
   "SHUFFLING": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:502",
+    "definedIn": "src/ui/queue.rs:512",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
Closes #282

Reduces animations for:
- lyric scroll-follow/line emphasis animation
- queue scroll-follow to the current track
- queue drag-edge auto-scroll
- release/album detail scroll-follow
- playlist drag-edge auto-scroll
- scrollbar fade/hide animation

Leaves the scrollbar staying always visible (which is also part of the `always_show_scrollbars` setting, but I feel like they should remain separate? willing to change this though)

## Changes
<!-- What specific changes were made? -->

## Testing
<!-- How did you test these changes? -->

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
