### PR TITLE
feat: inhibit sleep while playing 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ windows = { version = "0.62", features = [
     "Storage_Streams",
     "Win32_System_Com",
     "Win32_System_WinRT",
+    "Win32_System_Power",
     "Win32_System_Recovery"
 ] }
 windows-future = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ objc2-core-foundation = { version = "0.3", features = ["CFCGTypes"] }
 objc2-foundation = { version = "0.3", features = [
     "NSData",
     "NSDictionary",
+    "NSProcessInfo",
     "NSValue",
 ] }
 objc2-media-player = { version = "0.3", features = ["MPNowPlayingInfoCenter"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod logging;
 mod media;
 mod paths;
 mod playback;
+mod power;
 mod services;
 mod settings;
 #[cfg(test)]

--- a/src/playback/interface.rs
+++ b/src/playback/interface.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::{
     playback::events::RepeatState,
+    power::PowerManager,
     settings::playback::PlaybackSettings,
     ui::models::{CurrentTrack, ImageEvent, MMBSEvent, Models, PlaybackInfo},
 };
@@ -176,6 +177,7 @@ impl PlaybackInterface {
         let mmbs_model = app.global::<Models>().mmbs.clone();
 
         let playback_info = app.global::<PlaybackInfo>().clone();
+        let power_manager = app.global::<PowerManager>().clone();
 
         let Some(mut events_rx) = events_rx else {
             panic!("broadcast thread already started");
@@ -229,6 +231,8 @@ impl PlaybackInterface {
                                     cx.notify()
                                 });
                             }
+
+                            power_manager.set_state(cx, v);
 
                             mmbs_model.update(cx, |_, cx| {
                                 cx.emit(MMBSEvent::StateChanged(v));

--- a/src/power.rs
+++ b/src/power.rs
@@ -2,8 +2,11 @@
 mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
+#[cfg(target_os = "windows")]
+mod windows;
 
 use gpui::{AppContext, Entity, Global};
+use tracing::info;
 
 use crate::playback::thread::PlaybackState;
 
@@ -11,11 +14,13 @@ use crate::playback::thread::PlaybackState;
 use linux::PlatformPower;
 #[cfg(target_os = "macos")]
 use macos::PlatformPower;
+#[cfg(target_os = "windows")]
+use windows::PlatformPower;
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 struct PlatformPower;
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 impl PlatformPower {
     fn new() -> Self {
         Self

--- a/src/power.rs
+++ b/src/power.rs
@@ -1,0 +1,88 @@
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+
+use gpui::{AppContext, Entity, Global};
+
+use crate::playback::thread::PlaybackState;
+
+#[cfg(target_os = "linux")]
+use linux::PlatformPower;
+#[cfg(target_os = "macos")]
+use macos::PlatformPower;
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+struct PlatformPower;
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+impl PlatformPower {
+    fn new() -> Self {
+        Self
+    }
+
+    fn inhibit(&mut self) {}
+
+    fn uninhibit(&mut self) {}
+}
+
+struct PowerManagerInner {
+    platform: PlatformPower,
+    playing: bool,
+    prevent_idle: bool,
+}
+
+impl PowerManagerInner {
+    fn new(prevent_idle: bool) -> Self {
+        Self {
+            platform: PlatformPower::new(),
+            playing: false,
+            prevent_idle,
+        }
+    }
+
+    fn set_state(&mut self, state: PlaybackState) {
+        let playing = state == PlaybackState::Playing;
+        if self.playing == playing {
+            return;
+        }
+        self.playing = playing;
+        self.update();
+    }
+
+    fn set_prevent_idle(&mut self, prevent_idle: bool) {
+        if self.prevent_idle == prevent_idle {
+            return;
+        }
+        self.prevent_idle = prevent_idle;
+        self.update();
+    }
+
+    fn update(&mut self) {
+        if self.playing && self.prevent_idle {
+            self.platform.inhibit();
+        } else {
+            self.platform.uninhibit();
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PowerManager(Entity<PowerManagerInner>);
+
+impl Global for PowerManager {}
+
+impl PowerManager {
+    pub fn new(cx: &mut gpui::App, prevent_idle: bool) -> Self {
+        Self(cx.new(|_| PowerManagerInner::new(prevent_idle)))
+    }
+
+    pub fn set_state<C: AppContext>(&self, cx: &mut C, state: PlaybackState) {
+        self.0.update(cx, |inner, _| inner.set_state(state));
+    }
+
+    pub fn set_prevent_idle<C: AppContext>(&self, cx: &mut C, prevent_idle: bool) {
+        self.0
+            .update(cx, |inner, _| inner.set_prevent_idle(prevent_idle));
+    }
+}

--- a/src/power/linux.rs
+++ b/src/power/linux.rs
@@ -1,0 +1,89 @@
+use std::sync::OnceLock;
+
+use tokio::sync::Mutex;
+use zbus::Connection;
+
+const SERVICE: &str = "org.freedesktop.ScreenSaver";
+const PATH: &str = "/org/freedesktop/ScreenSaver";
+
+struct State {
+    connection: Option<Connection>,
+    cookie: Option<u32>,
+}
+
+static STATE: OnceLock<Mutex<State>> = OnceLock::new();
+
+fn state() -> &'static Mutex<State> {
+    STATE.get_or_init(|| {
+        Mutex::new(State {
+            connection: None,
+            cookie: None,
+        })
+    })
+}
+
+async fn connection(state: &mut State) -> Option<Connection> {
+    if state.connection.is_none() {
+        match Connection::session().await {
+            Ok(conn) => state.connection = Some(conn),
+            Err(e) => {
+                tracing::warn!("failed to connect to session bus: {e}");
+                return None;
+            }
+        }
+    }
+    state.connection.clone()
+}
+
+pub struct PlatformPower;
+
+impl PlatformPower {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn inhibit(&mut self) {
+        crate::RUNTIME.spawn(async {
+            let mut state = state().lock().await;
+            if state.cookie.is_some() {
+                return;
+            }
+            let Some(conn) = connection(&mut state).await else {
+                return;
+            };
+            let result: Result<u32, _> = conn
+                .call_method(
+                    Some(SERVICE),
+                    PATH,
+                    Some(SERVICE),
+                    "Inhibit",
+                    &("Hummingbird", "Playing media"),
+                )
+                .await
+                .and_then(|r| r.body().deserialize());
+
+            match result {
+                Ok(cookie) => state.cookie = Some(cookie),
+                Err(e) => tracing::warn!("failed to inhibit screen saver: {e}"),
+            }
+        });
+    }
+
+    pub fn uninhibit(&mut self) {
+        crate::RUNTIME.spawn(async {
+            let mut state = state().lock().await;
+            let Some(cookie) = state.cookie.take() else {
+                return;
+            };
+            let Some(conn) = connection(&mut state).await else {
+                return;
+            };
+            if let Err(e) = conn
+                .call_method(Some(SERVICE), PATH, Some(SERVICE), "UnInhibit", &(cookie))
+                .await
+            {
+                tracing::warn!("failed to uninhibit screen saver: {e}");
+            }
+        });
+    }
+}

--- a/src/power/macos.rs
+++ b/src/power/macos.rs
@@ -1,0 +1,32 @@
+use objc2::rc::Retained;
+use objc2::runtime::{NSObjectProtocol, ProtocolObject};
+use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
+
+pub struct PlatformPower {
+    activity: Option<Retained<ProtocolObject<dyn NSObjectProtocol>>>,
+}
+
+impl PlatformPower {
+    pub fn new() -> Self {
+        Self { activity: None }
+    }
+
+    pub fn inhibit(&mut self) {
+        if self.activity.is_some() {
+            return;
+        }
+        let process_info = NSProcessInfo::processInfo();
+        let reason = NSString::from_str("Hummingbird is playing media");
+        self.activity = Some(process_info.beginActivityWithOptions_reason(
+            NSActivityOptions::IdleDisplaySleepDisabled,
+            &reason,
+        ));
+    }
+
+    pub fn uninhibit(&mut self) {
+        let Some(activity) = self.activity.take() else {
+            return;
+        };
+        unsafe { NSProcessInfo::processInfo().endActivity(&activity) };
+    }
+}

--- a/src/power/windows.rs
+++ b/src/power/windows.rs
@@ -1,0 +1,66 @@
+use tracing::error;
+use windows::{
+    Win32::{
+        Foundation::{CloseHandle, HANDLE},
+        System::{
+            Power::{
+                PowerClearRequest, PowerCreateRequest, PowerRequestExecutionRequired,
+                PowerSetRequest,
+            },
+            SystemServices::POWER_REQUEST_CONTEXT_VERSION,
+            Threading::{POWER_REQUEST_CONTEXT_SIMPLE_STRING, REASON_CONTEXT, REASON_CONTEXT_0},
+        },
+    },
+    core::{PWSTR, w},
+};
+
+pub struct PlatformPower {
+    handle: Option<HANDLE>,
+}
+
+impl PlatformPower {
+    pub fn new() -> Self {
+        Self { handle: None }
+    }
+
+    pub fn inhibit(&mut self) {
+        let reason = w!("Playing music");
+
+        unsafe {
+            let context = REASON_CONTEXT {
+                Version: POWER_REQUEST_CONTEXT_VERSION,
+                Flags: POWER_REQUEST_CONTEXT_SIMPLE_STRING,
+                Reason: REASON_CONTEXT_0 {
+                    // very cool that this requires a mut pointer even though the string is never
+                    // mutated! i love windows
+                    SimpleReasonString: PWSTR(reason.as_ptr() as *mut _),
+                },
+            };
+
+            let Ok(handle) = PowerCreateRequest(&context) else {
+                error!("Failed to create power request handle, not inhibiting");
+                return;
+            };
+
+            if let Err(e) = PowerSetRequest(handle, PowerRequestExecutionRequired) {
+                error!("Failed to set power request: {:?}", e)
+            }
+
+            self.handle = Some(handle);
+        }
+    }
+
+    pub fn uninhibit(&mut self) {
+        unsafe {
+            if let Some(handle) = self.handle.take() {
+                if let Err(e) = PowerClearRequest(handle, PowerRequestExecutionRequired) {
+                    error!("Failed to clear power request: {:?}", e)
+                }
+
+                if let Err(e) = CloseHandle(handle) {
+                    error!("Failed to close power request handle: {:?}", e)
+                }
+            }
+        }
+    }
+}

--- a/src/settings/playback.rs
+++ b/src/settings/playback.rs
@@ -47,6 +47,9 @@ pub struct PlaybackSettings {
     /// ReplayGain settings.
     #[serde(default)]
     pub replaygain: ReplayGainSettings,
+
+    /// Whether to prevent the system screensaver and sleep while playing.
+    pub prevent_idle: bool,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -57,6 +60,7 @@ impl Default for PlaybackSettings {
             prev_track_jump_first: false,
             keep_current_on_queue_clear: true,
             replaygain: ReplayGainSettings::default(),
+            prevent_idle: false,
         }
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -23,6 +23,7 @@ use crate::{
         interface::PlaybackInterface, queue::QueueItemData,
         session_storage::PlaybackSessionStorageWorker, thread::PlaybackThread,
     },
+    power::PowerManager,
     services::controllers::{init_pbc_task, register_pbc_event_handlers},
     settings::{
         SettingsGlobal, setup_settings,
@@ -259,6 +260,9 @@ pub fn run() -> anyhow::Result<()> {
             scan_interface.start_broadcast(cx);
 
             cx.set_global(scan_interface);
+
+            let power_manager = PowerManager::new(cx, playback_settings.prevent_idle);
+            cx.set_global(power_manager);
 
             register_actions(cx);
 

--- a/src/ui/settings/playback.rs
+++ b/src/ui/settings/playback.rs
@@ -5,6 +5,7 @@ use gpui::{
 };
 
 use crate::{
+    power::PowerManager,
     settings::{Settings, SettingsGlobal, save_settings},
     ui::components::{
         checkbox::checkbox, label::label, labeled_slider::labeled_slider,
@@ -145,5 +146,29 @@ impl Render for PlaybackSettings {
                         }),
                 )
             })
+            .child(
+                label(
+                    "playback-prevent-idle",
+                    tr!("PLAYBACK_PREVENT_IDLE", "Prevent system idle when playing"),
+                )
+                .subtext(tr!(
+                    "PLAYBACK_PREVENT_IDLE_SUBTEXT",
+                    "Stops the screensaver and system sleep during playback."
+                ))
+                .cursor_pointer()
+                .w_full()
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    let prevent_idle = !this.settings.read(cx).playback.prevent_idle;
+                    this.update_playback(cx, |playback| {
+                        playback.prevent_idle = prevent_idle;
+                    });
+                    let power = cx.global::<PowerManager>().clone();
+                    power.set_prevent_idle(cx, prevent_idle);
+                }))
+                .child(checkbox(
+                    "playback-prevent-idle-check",
+                    playback.prevent_idle,
+                )),
+            )
     }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -117,6 +117,8 @@
   "PLAYBACK_ALWAYS_REPEAT_SUBTEXT": "Disables the \"Off\" repeat mode.",
   "PLAYBACK_KEEP_CURRENT_ON_CLEAR": "Keep current track when clearing queue",
   "PLAYBACK_KEEP_CURRENT_ON_CLEAR_SUBTEXT": "Preserves the currently playing song instead of removing all tracks.",
+  "PLAYBACK_PREVENT_IDLE": "Prevent system idle when playing",
+  "PLAYBACK_PREVENT_IDLE_SUBTEXT": "Stops the screensaver and system sleep during playback.",
   "PLAYBACK_PREVIOUS_JUMPS": "Previous button jumps to the beginning of the track if more than 5 seconds has elapsed",
   "PLAYBACK_RG_FALLBACK_PREAMP": "ReplayGain fallback pre-amp",
   "PLAYBACK_RG_FALLBACK_PREAMP_SUBTEXT": "Applied when tracks have no ReplayGain data.",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -649,43 +649,55 @@
   },
   "PLAYBACK_ALWAYS_REPEAT": {
     "context": "playback.rs",
-    "definedIn": "src/ui/settings/playback.rs:55",
+    "definedIn": "src/ui/settings/playback.rs:56",
     "plural": false,
     "description": null
   },
   "PLAYBACK_ALWAYS_REPEAT_SUBTEXT": {
     "context": "playback.rs",
-    "definedIn": "src/ui/settings/playback.rs:58",
+    "definedIn": "src/ui/settings/playback.rs:59",
     "plural": false,
     "description": null
   },
   "PLAYBACK_KEEP_CURRENT_ON_CLEAR": {
     "context": "playback.rs",
-    "definedIn": "src/ui/settings/playback.rs:98",
+    "definedIn": "src/ui/settings/playback.rs:99",
     "plural": false,
     "description": null
   },
   "PLAYBACK_KEEP_CURRENT_ON_CLEAR_SUBTEXT": {
     "context": "playback.rs",
-    "definedIn": "src/ui/settings/playback.rs:103",
+    "definedIn": "src/ui/settings/playback.rs:104",
+    "plural": false,
+    "description": null
+  },
+  "PLAYBACK_PREVENT_IDLE": {
+    "context": "playback.rs",
+    "definedIn": "src/ui/settings/playback.rs:152",
+    "plural": false,
+    "description": null
+  },
+  "PLAYBACK_PREVENT_IDLE_SUBTEXT": {
+    "context": "playback.rs",
+    "definedIn": "src/ui/settings/playback.rs:155",
     "plural": false,
     "description": null
   },
   "PLAYBACK_PREVIOUS_JUMPS": {
     "context": "playback.rs",
-    "definedIn": "src/ui/settings/playback.rs:77",
+    "definedIn": "src/ui/settings/playback.rs:78",
     "plural": false,
     "description": null
   },
   "PLAYBACK_RG_FALLBACK_PREAMP": {
     "context": "playback.rs",
-    "definedIn": "src/ui/settings/playback.rs:123",
+    "definedIn": "src/ui/settings/playback.rs:124",
     "plural": false,
     "description": null
   },
   "PLAYBACK_RG_FALLBACK_PREAMP_SUBTEXT": {
     "context": "playback.rs",
-    "definedIn": "src/ui/settings/playback.rs:126",
+    "definedIn": "src/ui/settings/playback.rs:127",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
Closes #179 

## Changes
Introduces Linux & macOS `PlatformPower` in `src/power/` and  `PowerManager` in `src/power.rs`. macOS uses `NSProcessInfo`'s `beginActivityWithOptions:reason:` to block, Linux uses the `org.freedesktop.ScreenSaver` `Inhibit` and `UnInhibit` dbus methods.

## Testing
Tested on macOS arm64 and Linux (running GNOME)

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
