### PR TITLE
fix: macos window lifecycle

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -55,6 +55,7 @@ use super::{
     models::{self, CurrentTrack, Models, PlaybackInfo, build_models},
     right_sidebar::RightSidebar,
     search::SearchView,
+    settings::close_last_settings_window,
     theme::setup_theme,
     util::drop_image_from_app,
 };
@@ -442,6 +443,11 @@ pub fn run() -> anyhow::Result<()> {
                     crate::logging::flush();
                 })
             }
+        })
+        .detach();
+
+        cx.on_window_closed(|cx, _window_id| {
+            close_last_settings_window(cx);
         })
         .detach();
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -164,6 +164,138 @@ pub struct DropImageDummyModel;
 
 impl EventEmitter<Vec<Arc<RenderImage>>> for DropImageDummyModel {}
 
+fn find_main_window(cx: &App) -> Option<WindowHandle<WindowShadow>> {
+    cx.windows()
+        .into_iter()
+        .find_map(|window| window.downcast::<WindowShadow>())
+}
+
+fn focus_main_window(window: WindowHandle<WindowShadow>, cx: &mut App) {
+    cx.activate(true);
+    cx.defer(move |cx| {
+        let _ = window.update(cx, |_, window, _| {
+            window.activate_window();
+        });
+    });
+}
+
+fn main_window_bounds(cx: &mut App) -> WindowBounds {
+    let window_information = cx.global::<Models>().window_information.read(cx).clone();
+
+    if let Some(window_information) = window_information {
+        if window_information.maximized {
+            WindowBounds::Maximized(Bounds::centered(None, window_information.size, cx))
+        } else {
+            WindowBounds::Windowed(Bounds::centered(None, window_information.size, cx))
+        }
+    } else {
+        WindowBounds::Maximized(Bounds::centered(None, size(px(1024.0), px(700.0)), cx))
+    }
+}
+
+fn main_window_options(window_bounds: WindowBounds) -> WindowOptions {
+    WindowOptions {
+        window_bounds: Some(window_bounds),
+        window_background: WindowBackgroundAppearance::Opaque,
+        window_decorations: Some(WindowDecorations::Client),
+        window_min_size: Some(size(px(800.0), px(600.0))),
+        titlebar: Some(TitlebarOptions {
+            title: Some(tr!("APP_NAME").into()),
+            appears_transparent: true,
+            traffic_light_position: Some(Point {
+                x: px(12.0),
+                y: px(11.0),
+            }),
+        }),
+        app_id: Some("org.mailliw.hummingbird".to_string()),
+        kind: WindowKind::Normal,
+        ..Default::default()
+    }
+}
+
+fn build_main_window(window: &mut Window, cx: &mut App) -> Entity<WindowShadow> {
+    let window_title = tr!("APP_NAME").to_string();
+    window.set_window_title(&window_title);
+
+    init_pbc_task(cx, window);
+
+    let palette = CommandPalette::new(cx, window);
+    cx.set_global(CommandPaletteHolder::new(palette.clone()));
+
+    cx.new(|cx| {
+        cx.observe_window_activation(window, |_, window, cx| {
+            cx.global::<PlaybackInterface>()
+                .set_position_broadcast_active(window.is_window_active());
+        })
+        .detach();
+
+        cx.observe_window_bounds(window, |_, window, cx| {
+            let window_information = cx.global::<Models>().window_information.clone();
+
+            let maximized = window.is_maximized();
+            let size = if maximized {
+                window_information.read(cx).clone()
+            } else {
+                None
+            }
+            .map(|v| v.size)
+            .unwrap_or(window.bounds().size);
+
+            window_information.write(cx, Some(WindowInformation { maximized, size }));
+        })
+        .detach();
+
+        cx.observe_window_appearance(window, |_, _, cx| {
+            cx.refresh_windows();
+        })
+        .detach();
+
+        let show_queue = cx.new(|_| true);
+        let show_lyrics = cx.new(|_| false);
+        let show_about = cx.global::<Models>().show_about.clone();
+        let about_focus = cx.focus_handle();
+
+        cx.observe(&show_about, |_, _, cx| {
+            cx.notify();
+        })
+        .detach();
+
+        WindowShadow {
+            controls: Controls::new(cx, show_queue.clone(), show_lyrics.clone()),
+            right_sidebar: RightSidebar::new(cx, show_queue.clone(), show_lyrics.clone()),
+            library: Library::new(cx),
+            header: Header::new(cx),
+            search: SearchView::new(cx),
+            show_queue,
+            show_lyrics,
+            show_about,
+            about_focus,
+            missing_folder_dialog: MissingFolderDialog::new(cx),
+            palette,
+            // use a really small global image cache
+            // this is literally just to ensure that images are *always* removed
+            // from memory *at some point*
+            //
+            // if your view uses a lot of images you need to have your own image
+            // cache
+            image_cache: HummingbirdImageCache::new(20, cx),
+        }
+    })
+}
+
+fn ensure_main_window(cx: &mut App) -> gpui::Result<WindowHandle<WindowShadow>> {
+    if let Some(window) = find_main_window(cx) {
+        focus_main_window(window, cx);
+        return Ok(window);
+    }
+
+    let bounds = main_window_bounds(cx);
+    let options = main_window_options(bounds);
+    let window = cx.open_window(options, build_main_window)?;
+    focus_main_window(window, cx);
+    Ok(window)
+}
+
 pub fn run() -> anyhow::Result<()> {
     let data_dir = paths::data_dir();
     fs::create_dir_all(&data_dir).inspect_err(|error| {
@@ -180,255 +312,154 @@ pub fn run() -> anyhow::Result<()> {
             tracing::error!(?error, "fatal: unable to create database pool");
         })?;
 
-    Application::with_platform(current_platform(false))
-        .with_assets(HummingbirdAssetSource::new(pool.clone()))
-        .run(move |cx: &mut App| {
-            // Fontconfig isn't read currently so fall back to the most "okay" font rendering
-            // option - I'm sure people will disagree with this but Grayscale font rendering
-            // results in text that is at least displayed correctly on all screens, unlike
-            // sub-pixel AA
-            #[cfg(target_os = "linux")]
-            cx.set_text_rendering_mode(TextRenderingMode::Grayscale);
+    let application = Application::with_platform(current_platform(false))
+        .with_assets(HummingbirdAssetSource::new(pool.clone()));
+    application.on_reopen(|cx| {
+        let _ = ensure_main_window(cx);
+    });
+    application.run(move |cx: &mut App| {
+        // Fontconfig isn't read currently so fall back to the most "okay" font rendering
+        // option - I'm sure people will disagree with this but Grayscale font rendering
+        // results in text that is at least displayed correctly on all screens, unlike
+        // sub-pixel AA
+        #[cfg(target_os = "linux")]
+        cx.set_text_rendering_mode(TextRenderingMode::Grayscale);
 
-            find_fonts(cx).expect("unable to load fonts");
+        find_fonts(cx).expect("unable to load fonts");
 
-            let storage = Storage::new(data_dir.join("app_data.json"));
-            let storage_data = storage.load_or_default();
+        let storage = Storage::new(data_dir.join("app_data.json"));
+        let storage_data = storage.load_or_default();
 
-            let session_file = data_dir.join("playback_session.json");
-            let playback_session = PlaybackSessionStorageWorker::load(&session_file);
-            let initial_position = playback_session
-                .queue_position
-                .filter(|position| *position < playback_session.queue.len());
-            let initial_track = initial_position
-                .and_then(|position| playback_session.queue.get(position))
-                .map(|item| CurrentTrack::new(item.get_path().clone()));
+        let session_file = data_dir.join("playback_session.json");
+        let playback_session = PlaybackSessionStorageWorker::load(&session_file);
+        let initial_position = playback_session
+            .queue_position
+            .filter(|position| *position < playback_session.queue.len());
+        let initial_track = initial_position
+            .and_then(|position| playback_session.queue.get(position))
+            .map(|item| CurrentTrack::new(item.get_path().clone()));
 
-            let queue: Arc<RwLock<Vec<QueueItemData>>> =
-                Arc::new(RwLock::new(playback_session.queue.clone()));
+        let queue: Arc<RwLock<Vec<QueueItemData>>> =
+            Arc::new(RwLock::new(playback_session.queue.clone()));
 
-            let (queue_tx, queue_rx) = tokio::sync::watch::channel(playback_session.clone());
-            crate::RUNTIME.spawn(PlaybackSessionStorageWorker::new(session_file, queue_rx).run());
+        let (queue_tx, queue_rx) = tokio::sync::watch::channel(playback_session.clone());
+        crate::RUNTIME.spawn(PlaybackSessionStorageWorker::new(session_file, queue_rx).run());
 
-            setup_settings(cx, data_dir.join("settings.json"));
-            setup_theme(cx, data_dir.clone());
-            cx.set_global(Pool(pool.clone()));
+        setup_settings(cx, data_dir.join("settings.json"));
+        setup_theme(cx, data_dir.clone());
+        cx.set_global(Pool(pool.clone()));
 
-            let settings = cx.global::<SettingsGlobal>().model.read(cx);
-            let language = settings.interface.language.clone();
-            let playback_settings = settings.playback.clone();
-            let scanning_settings = settings.scanning.clone();
-            #[cfg(feature = "update")]
-            let update_settings = settings.update.clone();
-            let initial_repeat = if playback_settings.always_repeat
-                && playback_session.repeat == crate::playback::events::RepeatState::NotRepeating
-            {
-                crate::playback::events::RepeatState::Repeating
-            } else {
-                playback_session.repeat
-            };
-            build_models(
-                cx,
-                models::Queue {
-                    data: queue.clone(),
-                    position: initial_position.unwrap_or(0),
-                },
-                &storage_data,
-                initial_track,
-                playback_session.shuffle,
-                initial_repeat,
-            );
+        let settings = cx.global::<SettingsGlobal>().model.read(cx);
+        let language = settings.interface.language.clone();
+        let playback_settings = settings.playback.clone();
+        let scanning_settings = settings.scanning.clone();
+        #[cfg(feature = "update")]
+        let update_settings = settings.update.clone();
+        let initial_repeat = if playback_settings.always_repeat
+            && playback_session.repeat == crate::playback::events::RepeatState::NotRepeating
+        {
+            crate::playback::events::RepeatState::Repeating
+        } else {
+            playback_session.repeat
+        };
+        build_models(
+            cx,
+            models::Queue {
+                data: queue.clone(),
+                position: initial_position.unwrap_or(0),
+            },
+            &storage_data,
+            initial_track,
+            playback_session.shuffle,
+            initial_repeat,
+        );
 
-            input::bind_actions(cx);
-            modal::bind_actions(cx);
-            library::bind_actions(cx);
-            dropdown::bind_actions(cx);
-            popover::bind_actions(cx);
-            context::bind_actions(cx);
+        input::bind_actions(cx);
+        modal::bind_actions(cx);
+        library::bind_actions(cx);
+        dropdown::bind_actions(cx);
+        popover::bind_actions(cx);
+        context::bind_actions(cx);
 
-            cx.set_global(modal::ModalActive(AtomicBool::new(false)));
+        cx.set_global(modal::ModalActive(AtomicBool::new(false)));
 
-            let settings_model = cx.global::<SettingsGlobal>().model.clone();
-            cx.observe(&settings_model, |_, cx| cx.refresh_windows())
-                .detach();
-
-            if !language.is_empty() {
-                I18N_MANAGER.write().unwrap().locale = Locale::new_from_locale_identifier(language);
-            }
-
-            let mut scan_interface: ScanInterface = start_scanner(pool.clone(), scanning_settings);
-            scan_interface.scan();
-            scan_interface.start_broadcast(cx);
-
-            cx.set_global(scan_interface);
-
-            let power_manager = PowerManager::new(cx, playback_settings.prevent_idle);
-            cx.set_global(power_manager);
-
-            register_actions(cx);
-
-            let drop_model = cx.new(|_| DropImageDummyModel);
-
-            cx.subscribe(&drop_model, |_, vec, cx| {
-                for image in vec.clone() {
-                    drop_image_from_app(cx, image);
-                }
-            })
+        let settings_model = cx.global::<SettingsGlobal>().model.clone();
+        cx.observe(&settings_model, |_, cx| cx.refresh_windows())
             .detach();
 
-            let last_volume = *cx.global::<PlaybackInfo>().volume.read(cx);
+        if !language.is_empty() {
+            I18N_MANAGER.write().unwrap().locale = Locale::new_from_locale_identifier(language);
+        }
 
-            let mut playback_interface: PlaybackInterface = PlaybackThread::start(
-                queue.clone(),
-                playback_settings,
-                last_volume,
-                playback_session,
-                queue_tx,
-            );
-            playback_interface.start_broadcast(cx);
+        let mut scan_interface: ScanInterface = start_scanner(pool.clone(), scanning_settings);
+        scan_interface.scan();
+        scan_interface.start_broadcast(cx);
 
-            if !parse_args_and_prepare(cx, &playback_interface)
-                && let Some(pos) = initial_position
-            {
-                playback_interface.jump(pos);
-                playback_interface.pause();
+        cx.set_global(scan_interface);
+
+        let power_manager = PowerManager::new(cx, playback_settings.prevent_idle);
+        cx.set_global(power_manager);
+
+        register_actions(cx);
+
+        let drop_model = cx.new(|_| DropImageDummyModel);
+
+        cx.subscribe(&drop_model, |_, vec, cx| {
+            for image in vec.clone() {
+                drop_image_from_app(cx, image);
             }
-            cx.set_global(playback_interface);
+        })
+        .detach();
 
-            #[cfg(feature = "update")]
-            if update_settings.auto_update {
-                crate::update::start_update_task(cx);
+        let last_volume = *cx.global::<PlaybackInfo>().volume.read(cx);
+
+        let mut playback_interface: PlaybackInterface = PlaybackThread::start(
+            queue.clone(),
+            playback_settings,
+            last_volume,
+            playback_session,
+            queue_tx,
+        );
+        playback_interface.start_broadcast(cx);
+
+        if !parse_args_and_prepare(cx, &playback_interface)
+            && let Some(pos) = initial_position
+        {
+            playback_interface.jump(pos);
+            playback_interface.pause();
+        }
+        cx.set_global(playback_interface);
+
+        // Update `StorageData` and save it to file system while quitting the app.
+        cx.on_app_quit({
+            let storage = storage.clone();
+            move |cx| {
+                let data = StorageData::new(cx);
+                let storage = storage.clone();
+
+                cx.background_executor().spawn(async move {
+                    storage.save(&data);
+                    crate::logging::flush();
+                })
             }
+        })
+        .detach();
 
-            cx.activate(true);
+        #[cfg(feature = "update")]
+        if update_settings.auto_update {
+            crate::update::start_update_task(cx);
+        }
 
-            let bounds = if let Some(window_information) = storage_data.window_information {
-                cx.global::<Models>()
-                    .window_information
-                    .clone()
-                    .write(cx, Some(window_information.clone()));
+        if let Some(window_information) = storage_data.window_information {
+            cx.global::<Models>()
+                .window_information
+                .clone()
+                .write(cx, Some(window_information.clone()));
+        }
 
-                if window_information.maximized {
-                    WindowBounds::Maximized(Bounds::centered(None, window_information.size, cx))
-                } else {
-                    WindowBounds::Windowed(Bounds::centered(None, window_information.size, cx))
-                }
-            } else {
-                WindowBounds::Maximized(Bounds::centered(None, size(px(1024.0), px(700.0)), cx))
-            };
-
-            cx.open_window(
-                WindowOptions {
-                    window_bounds: Some(bounds),
-                    window_background: WindowBackgroundAppearance::Opaque,
-                    window_decorations: Some(WindowDecorations::Client),
-                    window_min_size: Some(size(px(800.0), px(600.0))),
-                    titlebar: Some(TitlebarOptions {
-                        title: Some(tr!("APP_NAME").into()),
-                        appears_transparent: true,
-                        traffic_light_position: Some(Point {
-                            x: px(12.0),
-                            y: px(11.0),
-                        }),
-                    }),
-                    app_id: Some("org.mailliw.hummingbird".to_string()),
-                    kind: WindowKind::Normal,
-                    ..Default::default()
-                },
-                |window, cx| {
-                    window.set_window_title(tr!("APP_NAME").to_string().as_str());
-
-                    register_pbc_event_handlers(cx);
-                    init_pbc_task(cx, window);
-
-                    let palette = CommandPalette::new(cx, window);
-
-                    cx.set_global(CommandPaletteHolder::new(palette.clone()));
-
-                    // Update `StorageData` and save it to file system while quitting the app
-                    cx.on_app_quit({
-                        let storage = storage.clone();
-                        move |cx| {
-                            let data = StorageData::new(cx);
-                            let storage = storage.clone();
-
-                            cx.background_executor().spawn(async move {
-                                storage.save(&data);
-                                crate::logging::flush();
-                            })
-                        }
-                    })
-                    .detach();
-
-                    cx.new(|cx| {
-                        cx.observe_window_activation(window, |_, window, cx| {
-                            cx.global::<PlaybackInterface>()
-                                .set_position_broadcast_active(window.is_window_active());
-                        })
-                        .detach();
-
-                        cx.observe_window_bounds(window, |_, window, cx| {
-                            let window_information =
-                                cx.global::<Models>().window_information.clone();
-
-                            let maximized = window.is_maximized();
-                            let size = if maximized {
-                                window_information.read(cx).clone()
-                            } else {
-                                None
-                            }
-                            .map(|v| v.size)
-                            .unwrap_or(window.bounds().size);
-
-                            window_information
-                                .write(cx, Some(WindowInformation { maximized, size }));
-                        })
-                        .detach();
-
-                        cx.observe_window_appearance(window, |_, _, cx| {
-                            cx.refresh_windows();
-                        })
-                        .detach();
-
-                        let show_queue = cx.new(|_| true);
-                        let show_lyrics = cx.new(|_| false);
-                        let show_about = cx.global::<Models>().show_about.clone();
-                        let about_focus = cx.focus_handle();
-
-                        cx.observe(&show_about, |_, _, cx| {
-                            cx.notify();
-                        })
-                        .detach();
-
-                        WindowShadow {
-                            controls: Controls::new(cx, show_queue.clone(), show_lyrics.clone()),
-                            right_sidebar: RightSidebar::new(
-                                cx,
-                                show_queue.clone(),
-                                show_lyrics.clone(),
-                            ),
-                            library: Library::new(cx),
-                            header: Header::new(cx),
-                            search: SearchView::new(cx),
-                            show_queue,
-                            show_lyrics,
-                            show_about,
-                            about_focus,
-                            missing_folder_dialog: MissingFolderDialog::new(cx),
-                            palette,
-                            // use a really small global image cache
-                            // this is literally just to ensure that images are *always* removed
-                            // from memory *at some point*
-                            //
-                            // if your view uses a lot of images you need to have your own image
-                            // cache
-                            image_cache: HummingbirdImageCache::new(20, cx),
-                        }
-                    })
-                },
-            )
-            .unwrap();
-        });
+        ensure_main_window(cx).unwrap();
+        register_pbc_event_handlers(cx);
+    });
 
     Ok(())
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -55,7 +55,7 @@ use super::{
     models::{self, CurrentTrack, Models, PlaybackInfo, build_models},
     right_sidebar::RightSidebar,
     search::SearchView,
-    settings::close_last_settings_window,
+    settings::close_orphaned_settings_windows,
     theme::setup_theme,
     util::drop_image_from_app,
 };
@@ -169,6 +169,10 @@ fn find_main_window(cx: &App) -> Option<WindowHandle<WindowShadow>> {
     cx.windows()
         .into_iter()
         .find_map(|window| window.downcast::<WindowShadow>())
+}
+
+pub(super) fn has_main_window(cx: &App) -> bool {
+    find_main_window(cx).is_some()
 }
 
 fn focus_main_window(window: WindowHandle<WindowShadow>, cx: &mut App) {
@@ -447,7 +451,7 @@ pub fn run() -> anyhow::Result<()> {
         .detach();
 
         cx.on_window_closed(|cx, _window_id| {
-            close_last_settings_window(cx);
+            close_orphaned_settings_windows(cx);
         })
         .detach();
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -222,8 +222,6 @@ fn build_main_window(window: &mut Window, cx: &mut App) -> Entity<WindowShadow> 
     let window_title = tr!("APP_NAME").to_string();
     window.set_window_title(&window_title);
 
-    init_pbc_task(cx, window);
-
     let palette = CommandPalette::new(cx, window);
     cx.set_global(CommandPaletteHolder::new(palette.clone()));
 
@@ -467,7 +465,12 @@ pub fn run() -> anyhow::Result<()> {
                 .write(cx, Some(window_information.clone()));
         }
 
-        ensure_main_window(cx).unwrap();
+        let main_window = ensure_main_window(cx).unwrap();
+        main_window
+            .update(cx, |_, window, cx| {
+                init_pbc_task(cx, window);
+            })
+            .unwrap();
         register_pbc_event_handlers(cx);
     });
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -60,7 +60,7 @@ use super::{
     util::drop_image_from_app,
 };
 
-struct WindowShadow {
+struct MainWindow {
     pub controls: Entity<Controls>,
     pub right_sidebar: Entity<RightSidebar>,
     pub library: Entity<Library>,
@@ -75,7 +75,7 @@ struct WindowShadow {
     pub image_cache: Entity<HummingbirdImageCache>,
 }
 
-impl Render for WindowShadow {
+impl Render for MainWindow {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         cx.global::<ModalActive>().0.store(false, Ordering::Relaxed);
 
@@ -165,17 +165,17 @@ pub struct DropImageDummyModel;
 
 impl EventEmitter<Vec<Arc<RenderImage>>> for DropImageDummyModel {}
 
-fn find_main_window(cx: &App) -> Option<WindowHandle<WindowShadow>> {
+fn find_main_window(cx: &App) -> Option<WindowHandle<MainWindow>> {
     cx.windows()
         .into_iter()
-        .find_map(|window| window.downcast::<WindowShadow>())
+        .find_map(|window| window.downcast::<MainWindow>())
 }
 
 pub(super) fn has_main_window(cx: &App) -> bool {
     find_main_window(cx).is_some()
 }
 
-fn focus_main_window(window: WindowHandle<WindowShadow>, cx: &mut App) {
+fn focus_main_window(window: WindowHandle<MainWindow>, cx: &mut App) {
     cx.activate(true);
     cx.defer(move |cx| {
         let _ = window.update(cx, |_, window, _| {
@@ -218,7 +218,7 @@ fn main_window_options(window_bounds: WindowBounds) -> WindowOptions {
     }
 }
 
-fn build_main_window(window: &mut Window, cx: &mut App) -> Entity<WindowShadow> {
+fn build_main_window(window: &mut Window, cx: &mut App) -> Entity<MainWindow> {
     let window_title = tr!("APP_NAME").to_string();
     window.set_window_title(&window_title);
 
@@ -263,7 +263,7 @@ fn build_main_window(window: &mut Window, cx: &mut App) -> Entity<WindowShadow> 
         })
         .detach();
 
-        WindowShadow {
+        MainWindow {
             controls: Controls::new(cx, show_queue.clone(), show_lyrics.clone()),
             right_sidebar: RightSidebar::new(cx, show_queue.clone(), show_lyrics.clone()),
             library: Library::new(cx),
@@ -286,7 +286,7 @@ fn build_main_window(window: &mut Window, cx: &mut App) -> Entity<WindowShadow> 
     })
 }
 
-fn ensure_main_window(cx: &mut App) -> gpui::Result<WindowHandle<WindowShadow>> {
+fn ensure_main_window(cx: &mut App) -> gpui::Result<WindowHandle<MainWindow>> {
     if let Some(window) = find_main_window(cx) {
         focus_main_window(window, cx);
         return Ok(window);

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -145,6 +145,15 @@ impl HasLikedState for InfoSection {
     }
 }
 
+fn update_track_metadata(this: &mut InfoSection, metadata: &crate::media::metadata::Metadata) {
+    this.track_name = metadata.name.clone().map(SharedString::from);
+    this.artist_name = metadata
+        .artist
+        .clone()
+        .or(metadata.album_artist.clone())
+        .map(SharedString::from);
+}
+
 impl InfoSection {
     pub fn new(cx: &mut App) -> Entity<Self> {
         cx.new(|cx| {
@@ -158,15 +167,7 @@ impl InfoSection {
             .detach();
 
             cx.observe(&metadata_model, |this: &mut Self, m, cx| {
-                let metadata = m.read(cx);
-
-                this.track_name = metadata.name.clone().map(SharedString::from);
-                this.artist_name = metadata
-                    .artist
-                    .clone()
-                    .or(metadata.album_artist.clone())
-                    .map(SharedString::from);
-
+                update_track_metadata(this, m.read(cx));
                 cx.notify();
             })
             .detach();
@@ -200,12 +201,13 @@ impl InfoSection {
                 cx.playlist_has_track(LIKED_SONGS_PLAYLIST_ID, track.id)
                     .unwrap_or_default()
             });
+            let initial_metadata = metadata_model.read(cx).clone();
 
             subscribe_liked_updates(cx, |this: &Self| {
                 this.current_library_track.as_ref().map(|t| t.id)
             });
 
-            Self {
+            let mut info_section = Self {
                 artist_name: None,
                 track_name: None,
                 playback_info,
@@ -216,7 +218,10 @@ impl InfoSection {
                 can_navigate_to_artist,
                 image_element_key: 0,
                 is_liked,
-            }
+            };
+            update_track_metadata(&mut info_section, &initial_metadata);
+
+            info_section
         })
     }
 }

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -339,15 +339,63 @@ fn make_view(
     }
 }
 
+fn library_section_from_history(history: &NavigationHistory) -> LibrarySection {
+    LibrarySection::from_message(&history.current())
+        .or_else(|| {
+            history
+                .last_matching(ViewSwitchMessage::is_key_page)
+                .and_then(|message| LibrarySection::from_message(&message))
+        })
+        .unwrap_or(LibrarySection::Albums)
+}
+
 impl Library {
+    fn sync_visible_views(&mut self, model: &Entity<NavigationHistory>, cx: &mut App) {
+        let history = model.read(cx);
+        let current_msg = history.current();
+        let two_column = cx
+            .global::<crate::settings::SettingsGlobal>()
+            .model
+            .read(cx)
+            .interface
+            .two_column_library;
+
+        self.section = library_section_from_history(&history);
+
+        if two_column {
+            if current_msg.is_detail_page() {
+                self.right_view = Some(self.view.clone());
+
+                let left_msg = history.last_matching(ViewSwitchMessage::is_key_page);
+
+                let needs_new_left = match (&self.left_view, &left_msg) {
+                    (None, Some(_)) | (Some(_), None) => true,
+                    (Some(lv), Some(msg)) => !msg.library_view_matches(lv),
+                    (None, None) => false,
+                };
+
+                if needs_new_left {
+                    self.left_view = left_msg
+                        .as_ref()
+                        .map(|message| make_view(message, cx, model, &self.scroll_state));
+                }
+            } else {
+                self.left_view = Some(self.view.clone());
+                self.right_view = None;
+            }
+        } else {
+            self.left_view = None;
+            self.right_view = None;
+        }
+    }
+
     pub fn new(cx: &mut App) -> Entity<Self> {
         cx.new(|cx| {
             let switcher_model = cx.global::<Models>().switcher_model.clone();
             let scroll_state = ScrollStateStorage::default();
             let initial_message = switcher_model.read(cx).current();
             let view = make_view(&initial_message, cx, &switcher_model, &scroll_state);
-            let section =
-                LibrarySection::from_message(&initial_message).unwrap_or(LibrarySection::Albums);
+            let section = library_section_from_history(&switcher_model.read(cx));
 
             cx.subscribe(
                 &switcher_model,
@@ -380,9 +428,6 @@ impl Library {
 
                             if let Some(dest) = destination {
                                 debug!("back → {:?}", dest);
-                                if let Some(s) = LibrarySection::from_message(&dest) {
-                                    this.section = s;
-                                }
                                 make_view(&dest, cx, &m, &this.scroll_state)
                             } else {
                                 this.view.clone()
@@ -399,9 +444,6 @@ impl Library {
 
                             if let Some(dest) = destination {
                                 debug!("forward → {:?}", dest);
-                                if let Some(s) = LibrarySection::from_message(&dest) {
-                                    this.section = s;
-                                }
                                 make_view(&dest, cx, &m, &this.scroll_state)
                             } else {
                                 this.view.clone()
@@ -414,10 +456,6 @@ impl Library {
                         }
 
                         _ => {
-                            if let Some(s) = LibrarySection::from_message(message) {
-                                this.section = s;
-                            }
-
                             m.update(cx, |history, cx| {
                                 history.navigate(*message);
                                 cx.notify();
@@ -427,41 +465,7 @@ impl Library {
                         }
                     };
 
-                    let two_column = cx
-                        .global::<crate::settings::SettingsGlobal>()
-                        .model
-                        .read(cx)
-                        .interface
-                        .two_column_library;
-
-                    if two_column {
-                        let current_msg = m.read(cx).current();
-                        if current_msg.is_detail_page() {
-                            this.right_view = Some(this.view.clone());
-
-                            let left_msg = m.read(cx).last_matching(ViewSwitchMessage::is_key_page);
-
-                            let needs_new_left = match (&this.left_view, &left_msg) {
-                                (None, Some(_)) | (Some(_), None) => true,
-
-                                (Some(lv), Some(msg)) => !msg.library_view_matches(lv),
-                                (None, None) => false,
-                            };
-
-                            if needs_new_left {
-                                this.left_view = left_msg
-                                    .as_ref()
-                                    .map(|lm| make_view(lm, cx, &m, &this.scroll_state));
-                            }
-                        } else {
-                            // Key page: show full-width in left pane, clear right
-                            this.left_view = Some(this.view.clone());
-                            this.right_view = None;
-                        }
-                    } else {
-                        this.left_view = None;
-                        this.right_view = None;
-                    }
+                    this.sync_visible_views(&m, cx);
 
                     cx.notify();
                 },
@@ -498,9 +502,16 @@ impl Library {
             let show_update_playlist = cx.new(|_| false);
 
             let settings = cx.global::<crate::settings::SettingsGlobal>().model.clone();
-            cx.observe(&settings, |_, _, cx| cx.notify()).detach();
+            cx.observe(&settings, {
+                let switcher_model = switcher_model.clone();
+                move |this: &mut Library, _, cx| {
+                    this.sync_visible_views(&switcher_model, cx);
+                    cx.notify();
+                }
+            })
+            .detach();
 
-            Library {
+            let mut library = Library {
                 sidebar: Sidebar::new(cx, switcher_model.clone()),
                 view,
                 left_view: None,
@@ -512,7 +523,9 @@ impl Library {
                 scroll_state,
                 reclaim_focus: false,
                 _focus_lost_sub: None,
-            }
+            };
+            library.sync_visible_views(&switcher_model, cx);
+            library
         })
     }
 }

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -360,7 +360,7 @@ impl Library {
             .interface
             .two_column_library;
 
-        self.section = library_section_from_history(&history);
+        self.section = library_section_from_history(history);
 
         if two_column {
             if current_msg.is_detail_page() {
@@ -395,7 +395,7 @@ impl Library {
             let scroll_state = ScrollStateStorage::default();
             let initial_message = switcher_model.read(cx).current();
             let view = make_view(&initial_message, cx, &switcher_model, &scroll_state);
-            let section = library_section_from_history(&switcher_model.read(cx));
+            let section = library_section_from_history(switcher_model.read(cx));
 
             cx.subscribe(
                 &switcher_model,

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -66,6 +66,20 @@ pub fn open_settings_window(cx: &mut App) {
     .ok();
 }
 
+pub(super) fn close_last_settings_window(cx: &mut App) {
+    if let Some(existing_window) = cx
+        .windows()
+        .into_iter()
+        .find_map(|window| window.downcast::<SettingsWindow>())
+        && cx.windows().len() == 1
+    {
+        cx.update_window(*existing_window, |_, window, _| {
+            window.remove_window();
+        })
+        .ok();
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SettingsSectionKind {
     Interface,

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -66,14 +66,19 @@ pub fn open_settings_window(cx: &mut App) {
     .ok();
 }
 
-pub(super) fn close_last_settings_window(cx: &mut App) {
-    if let Some(existing_window) = cx
+pub(super) fn close_orphaned_settings_windows(cx: &mut App) {
+    if super::app::has_main_window(cx) {
+        return;
+    }
+
+    let settings_windows = cx
         .windows()
         .into_iter()
-        .find_map(|window| window.downcast::<SettingsWindow>())
-        && cx.windows().len() == 1
-    {
-        cx.update_window(*existing_window, |_, window, _| {
+        .filter_map(|window| window.downcast::<SettingsWindow>())
+        .collect::<Vec<_>>();
+
+    for settings_window in settings_windows {
+        cx.update_window(*settings_window, |_, window, _| {
             window.remove_window();
         })
         .ok();

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -127,7 +127,7 @@
   },
   "ACTION_GROUP_PLAYLIST": {
     "context": "library.rs",
-    "definedIn": "src/ui/library.rs:486",
+    "definedIn": "src/ui/library.rs:490",
     "plural": false,
     "description": null
   },
@@ -139,7 +139,7 @@
   },
   "ACTION_IMPORT_PLAYLIST": {
     "context": "library.rs",
-    "definedIn": "src/ui/library.rs:487",
+    "definedIn": "src/ui/library.rs:491",
     "plural": false,
     "description": null
   },
@@ -217,7 +217,7 @@
   },
   "APP_NAME": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:328",
+    "definedIn": "src/ui/controls.rs:333",
     "plural": false,
     "description": "Use the english name everywhere unless this is strictly disagreeable.\n                                "
   },
@@ -589,7 +589,7 @@
   },
   "LIKE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:407",
+    "definedIn": "src/ui/controls.rs:412",
     "plural": false,
     "description": null
   },
@@ -613,13 +613,13 @@
   },
   "LYRICS": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:1035",
+    "definedIn": "src/ui/controls.rs:1040",
     "plural": false,
     "description": null
   },
   "MUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:970",
+    "definedIn": "src/ui/controls.rs:975",
     "plural": false,
     "description": null
   },
@@ -631,7 +631,7 @@
   },
   "NEXT_TRACK": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:628",
+    "definedIn": "src/ui/controls.rs:633",
     "plural": false,
     "description": null
   },
@@ -745,7 +745,7 @@
   },
   "PREVIOUS_TRACK": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:576",
+    "definedIn": "src/ui/controls.rs:581",
     "plural": false,
     "description": null
   },
@@ -817,19 +817,19 @@
   },
   "REPEAT": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:706",
+    "definedIn": "src/ui/controls.rs:711",
     "plural": false,
     "description": null
   },
   "REPEAT_OFF": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:696",
+    "definedIn": "src/ui/controls.rs:701",
     "plural": false,
     "description": null
   },
   "REPEAT_ONE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:715",
+    "definedIn": "src/ui/controls.rs:720",
     "plural": false,
     "description": null
   },
@@ -1183,13 +1183,13 @@
   },
   "STOP_REPEATING": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:674",
+    "definedIn": "src/ui/controls.rs:679",
     "plural": false,
     "description": null
   },
   "STOP_SHUFFLING": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:546",
+    "definedIn": "src/ui/controls.rs:551",
     "plural": false,
     "description": null
   },
@@ -1249,19 +1249,19 @@
   },
   "UNKNOWN_ARTIST": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:375",
+    "definedIn": "src/ui/controls.rs:380",
     "plural": false,
     "description": null
   },
   "UNKNOWN_TRACK": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:361",
+    "definedIn": "src/ui/controls.rs:366",
     "plural": false,
     "description": null
   },
   "UNLIKE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:404",
+    "definedIn": "src/ui/controls.rs:409",
     "plural": false,
     "description": null
   },
@@ -1273,7 +1273,7 @@
   },
   "UNMUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:963",
+    "definedIn": "src/ui/controls.rs:968",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -457,7 +457,7 @@
   },
   "INTERFACE": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:104",
+    "definedIn": "src/ui/settings.rs:118",
     "plural": false,
     "description": null
   },
@@ -565,7 +565,7 @@
   },
   "LIBRARY": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:105",
+    "definedIn": "src/ui/settings.rs:119",
     "plural": false,
     "description": null
   },
@@ -667,7 +667,7 @@
   },
   "PLAYBACK": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:106",
+    "definedIn": "src/ui/settings.rs:120",
     "plural": false,
     "description": null
   },
@@ -1045,7 +1045,7 @@
   },
   "SERVICES": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:107",
+    "definedIn": "src/ui/settings.rs:121",
     "plural": false,
     "description": null
   },
@@ -1285,7 +1285,7 @@
   },
   "UPDATE": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:109",
+    "definedIn": "src/ui/settings.rs:123",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -457,7 +457,7 @@
   },
   "INTERFACE": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:118",
+    "definedIn": "src/ui/settings.rs:123",
     "plural": false,
     "description": null
   },
@@ -565,7 +565,7 @@
   },
   "LIBRARY": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:119",
+    "definedIn": "src/ui/settings.rs:124",
     "plural": false,
     "description": null
   },
@@ -667,7 +667,7 @@
   },
   "PLAYBACK": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:120",
+    "definedIn": "src/ui/settings.rs:125",
     "plural": false,
     "description": null
   },
@@ -1045,7 +1045,7 @@
   },
   "SERVICES": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:121",
+    "definedIn": "src/ui/settings.rs:126",
     "plural": false,
     "description": null
   },
@@ -1285,7 +1285,7 @@
   },
   "UPDATE": {
     "context": "settings.rs",
-    "definedIn": "src/ui/settings.rs:123",
+    "definedIn": "src/ui/settings.rs:128",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
On macOS, closing Hummingbird with the close button could leave the app in a limbo state where playback continued in the background but the main window couldn't be restored normally by clicking the dock icon & the only fix was to force quit and relaunch it

- before

https://github.com/user-attachments/assets/9d3f17f0-0067-49e6-862f-8deafc79d97f


<!-- What specific changes were made? -->

My fix was using `gpui`'s `on_reopen` handler/callback and moving the main window creation into reusable code. It lets the app focus the existing window if one is already open, or create a new main window when the user clicks the dock icon and no windows are open; this is is more or less the same approach of zed. I also fixed a bug in `controls.rs` where reopening the window during playback would show Unknown Track / Unknown Artist because the controls view only populated its labels from future metadata events

I also refactored a bit of`library.rs` to centralize how the library derives one-column vs two-column pane state from the current navigation history and interface settings. before this part of the split view only got recomputed after another navigation event, causing reopening the window to restore a single column window when two-column was toggled on

## Testing

- after

https://github.com/user-attachments/assets/015860e6-24eb-40b4-a702-55533ea75355

https://github.com/user-attachments/assets/a1e80133-7e64-48e6-9e77-93348de8e332

>[!NOTE]
I didn’t test this on Linux or Windows, but this should be low-risk cross-platform since the reopen fix is using GPUI’s normal app/window hooks, and the `controls.rs` / `library.rs` changes are just fixing how recreated views hydrate from existing state. The main platform-specific part of this bug was the macOS dock reopen behavior

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [x] Documentation added/updated where needed
- [x] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
