### PR TITLE
feat: add "Swap menu and navigation buttons" setting

### DIFF
--- a/src/settings/interface.rs
+++ b/src/settings/interface.rs
@@ -44,6 +44,9 @@ pub struct InterfaceSettings {
     pub reduced_motion: bool,
     #[serde(default)]
     pub always_show_scrollbars: bool,
+    #[cfg(not(target_os = "macos"))]
+    #[serde(default)]
+    pub swap_menu_and_nav: bool,
 }
 
 impl InterfaceSettings {
@@ -53,6 +56,17 @@ impl InterfaceSettings {
 
     pub fn effective_full_width(&self) -> bool {
         self.full_width_library || self.two_column_library
+    }
+
+    pub fn should_swap_menu_and_nav(&self) -> bool {
+        #[cfg(not(target_os = "macos"))]
+        {
+            self.swap_menu_and_nav
+        }
+        #[cfg(target_os = "macos")]
+        {
+            false
+        }
     }
 }
 
@@ -67,6 +81,8 @@ impl Default for InterfaceSettings {
             grid_min_item_width: DEFAULT_GRID_MIN_ITEM_WIDTH,
             reduced_motion: false,
             always_show_scrollbars: false,
+            #[cfg(not(target_os = "macos"))]
+            swap_menu_and_nav: false,
         }
     }
 }

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -11,6 +11,7 @@ use tracing::{info, warn};
 use crate::{
     library::scan::ScanEvent,
     services::mmb::lastfm::LASTFM_CREDS,
+    settings::{Settings, SettingsGlobal},
     ui::{
         components::{
             icons::{FOLDER_SEARCH, icon},
@@ -27,6 +28,7 @@ pub struct Header {
     scan_status: Entity<ScanStatus>,
     menu_bar: Option<Entity<MenuBar>>,
     lastfm: Option<Entity<lastfm::LastFM>>,
+    settings: Entity<Settings>,
 }
 
 impl Header {
@@ -41,27 +43,42 @@ impl Header {
             info!("These can additionally be set at compile time to bake them into the binary.");
         }
 
-        cx.new(|cx| Self {
-            scan_status: ScanStatus::new(cx),
-            menu_bar: if cfg!(not(target_os = "macos")) {
-                let menus = cx.get_menus().unwrap();
-                Some(MenuBar::new(cx, menus))
-            } else {
-                None
-            },
-            lastfm,
+        let settings = cx.global::<SettingsGlobal>().model.clone();
+
+        cx.new(|cx| {
+            cx.observe(&settings, |_, _, cx| cx.notify()).detach();
+
+            Self {
+                scan_status: ScanStatus::new(cx),
+                menu_bar: if cfg!(not(target_os = "macos")) {
+                    let menus = cx.get_menus().unwrap();
+                    Some(MenuBar::new(cx, menus))
+                } else {
+                    None
+                },
+                lastfm,
+                settings,
+            }
         })
     }
 }
 
 impl Render for Header {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let mut header = header().main_window(true);
 
-        header = header.left(nav_buttons());
+        let swap = self.settings.read(cx).interface.should_swap_menu_and_nav();
 
-        if let Some(menu_bar) = self.menu_bar.clone() {
-            header = header.left(menu_bar);
+        if swap {
+            if let Some(menu_bar) = self.menu_bar.clone() {
+                header = header.left(menu_bar);
+            }
+            header = header.left(nav_buttons());
+        } else {
+            header = header.left(nav_buttons());
+            if let Some(menu_bar) = self.menu_bar.clone() {
+                header = header.left(menu_bar);
+            }
         }
 
         header = header.left(self.scan_status.clone());

--- a/src/ui/settings/interface.rs
+++ b/src/ui/settings/interface.rs
@@ -184,7 +184,7 @@ impl Render for InterfaceSettings {
                 })
         };
 
-        div()
+        let body = div()
             .flex()
             .flex_col()
             .gap(px(14.0))
@@ -338,6 +338,35 @@ impl Render for InterfaceSettings {
                     "interface-always-show-scrollbars-check",
                     interface.always_show_scrollbars,
                 )),
+            );
+
+        #[cfg(not(target_os = "macos"))]
+        let body = body.child(
+            label(
+                "interface-swap-menu-and-nav",
+                tr!(
+                    "INTERFACE_SWAP_MENU_AND_NAV",
+                    "Swap menu and navigation buttons"
+                ),
             )
+            .subtext(tr!(
+                "INTERFACE_SWAP_MENU_AND_NAV_SUBTEXT",
+                "Place the menu before the back/forward buttons so navigation sits closer \
+                to the center of the window."
+            ))
+            .cursor_pointer()
+            .w_full()
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.update_interface(cx, |interface| {
+                    interface.swap_menu_and_nav = !interface.swap_menu_and_nav;
+                });
+            }))
+            .child(checkbox(
+                "interface-swap-menu-and-nav-check",
+                interface.swap_menu_and_nav,
+            )),
+        );
+
+        body
     }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -89,6 +89,8 @@
   "INTERFACE_REDUCED_MOTION_SUBTEXT": "Disables smooth scrolling, fades, and other motion-heavy UI animations.",
   "INTERFACE_STARTUP_LIBRARY_VIEW": "Default startup view",
   "INTERFACE_STARTUP_LIBRARY_VIEW_SUBTEXT": "Choose which library page opens when Hummingbird launches.",
+  "INTERFACE_SWAP_MENU_AND_NAV": "Swap menu and navigation buttons",
+  "INTERFACE_SWAP_MENU_AND_NAV_SUBTEXT": "Place the menu before the back/forward buttons so navigation sits closer to the center of the window.",
   "INTERFACE_THEME": "Theme",
   "INTERFACE_THEME_SUBTEXT": "Choose a built-in theme or add your own. Place custom theme files in the themes folder. Changes apply immediately.",
   "INTERFACE_TWO_COLUMN_LIBRARY": "Two-column library",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -521,6 +521,18 @@
     "plural": false,
     "description": null
   },
+  "INTERFACE_SWAP_MENU_AND_NAV": {
+    "context": "interface.rs",
+    "definedIn": "src/ui/settings/interface.rs:348",
+    "plural": false,
+    "description": null
+  },
+  "INTERFACE_SWAP_MENU_AND_NAV_SUBTEXT": {
+    "context": "interface.rs",
+    "definedIn": "src/ui/settings/interface.rs:353",
+    "plural": false,
+    "description": null
+  },
   "INTERFACE_THEME": {
     "context": "interface.rs",
     "definedIn": "src/ui/settings/interface.rs:203",
@@ -1015,19 +1027,19 @@
   },
   "SCAN_COMPLETE_WATCHING": {
     "context": "header.rs",
-    "definedIn": "src/ui/header.rs:163",
+    "definedIn": "src/ui/header.rs:180",
     "plural": false,
     "description": null
   },
   "SCAN_PROGRESS_DISCOVERING": {
     "context": "header.rs",
-    "definedIn": "src/ui/header.rs:142",
+    "definedIn": "src/ui/header.rs:159",
     "plural": false,
     "description": null
   },
   "SCAN_PROGRESS_SCANNING": {
     "context": "header.rs",
-    "definedIn": "src/ui/header.rs:150",
+    "definedIn": "src/ui/header.rs:167",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
Closes #301 

## Changes
Adds a setting to swap the position of menu/nav buttons

## Testing
Tested on Linux/macOS (setting doesn't show up)

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
