### PR TITLE
feat: queue multi-selection with batch actions and multi-drag

### DIFF
--- a/src/playback/events.rs
+++ b/src/playback/events.rs
@@ -74,6 +74,8 @@ pub enum PlaybackCommand {
     SetRepeat(RepeatState),
     /// Requests that the item at the index provided be removed from the queue.
     RemoveItem(usize),
+    /// Requests that the items at the indices provided be removed from the queue.
+    RemoveItems(Vec<usize>),
     /// Requests that an item be moved from one position to another in the queue.
     /// The first usize is the source index, the second is the destination index.
     MoveItem { from: usize, to: usize },

--- a/src/playback/events.rs
+++ b/src/playback/events.rs
@@ -79,6 +79,10 @@ pub enum PlaybackCommand {
     /// Requests that an item be moved from one position to another in the queue.
     /// The first usize is the source index, the second is the destination index.
     MoveItem { from: usize, to: usize },
+    /// Requests that multiple items be moved to a single destination in the queue.
+    /// The source indices are sorted in ascending order; the destination is the final
+    /// position after all items have been moved.
+    MoveItems { indices: Vec<usize>, to: usize },
     /// Requests that the last queue mutation be undone.
     Undo,
     /// Informs the playback thread that the playback settings have changed.

--- a/src/playback/interface.rs
+++ b/src/playback/interface.rs
@@ -139,6 +139,10 @@ impl PlaybackInterface {
         self.cmd_tx.send(PlaybackCommand::RemoveItem(idx)).unwrap();
     }
 
+    pub fn remove_items(&self, indices: Vec<usize>) {
+        self.cmd_tx.send(PlaybackCommand::RemoveItems(indices)).unwrap();
+    }
+
     pub fn move_item(&self, from: usize, to: usize) {
         self.cmd_tx
             .send(PlaybackCommand::MoveItem { from, to })

--- a/src/playback/interface.rs
+++ b/src/playback/interface.rs
@@ -140,12 +140,20 @@ impl PlaybackInterface {
     }
 
     pub fn remove_items(&self, indices: Vec<usize>) {
-        self.cmd_tx.send(PlaybackCommand::RemoveItems(indices)).unwrap();
+        self.cmd_tx
+            .send(PlaybackCommand::RemoveItems(indices))
+            .unwrap();
     }
 
     pub fn move_item(&self, from: usize, to: usize) {
         self.cmd_tx
             .send(PlaybackCommand::MoveItem { from, to })
+            .unwrap();
+    }
+
+    pub fn move_items(&self, indices: Vec<usize>, to: usize) {
+        self.cmd_tx
+            .send(PlaybackCommand::MoveItems { indices, to })
             .unwrap();
     }
 

--- a/src/playback/thread.rs
+++ b/src/playback/thread.rs
@@ -33,8 +33,8 @@ use super::{
 
 use audio_engine::{AudioEngine, EngineCycleResult, EngineState};
 use queue_manager::{
-    DequeueResult, InsertResult, JumpResult, MoveResult, QueueManager, QueueNavigationResult,
-    ReplaceResult, Reshuffled, ShuffleResult, UndoResult,
+    DequeueManyResult, DequeueResult, InsertResult, JumpResult, MoveResult, QueueManager,
+    QueueNavigationResult, ReplaceResult, Reshuffled, ShuffleResult, UndoResult,
 };
 
 // throttle position broadcasts to prevent excees CPU utilization, especially while the application isn't
@@ -193,6 +193,7 @@ impl PlaybackThread {
                 PlaybackCommand::ToggleShuffle => self.toggle_shuffle(),
                 PlaybackCommand::SetRepeat(v) => self.set_repeat(v),
                 PlaybackCommand::RemoveItem(idx) => self.remove(idx),
+                PlaybackCommand::RemoveItems(indices) => self.remove_many(&indices),
                 PlaybackCommand::MoveItem { from, to } => self.move_item(from, to),
                 PlaybackCommand::Undo => self.undo(),
                 PlaybackCommand::SettingsChanged(settings) => self.settings_changed(settings),
@@ -575,6 +576,37 @@ impl PlaybackThread {
                 }
             }
             DequeueResult::Unchanged => {}
+        }
+    }
+
+    fn remove_many(&mut self, indices: &[usize]) {
+        match self.queue.dequeue_many(indices.to_vec()) {
+            DequeueManyResult::Removed { new_position } => {
+                self.refresh_rg_auto_hint();
+                self.send_event(PlaybackEvent::QueueUpdated);
+
+                if let Some(current) = self.queue.current_position()
+                    && current != new_position
+                {
+                    self.send_event(PlaybackEvent::QueuePositionChanged(new_position));
+                }
+            }
+            DequeueManyResult::RemovedCurrent { new_path } => {
+                self.refresh_rg_auto_hint();
+                self.send_event(PlaybackEvent::QueueUpdated);
+
+                if let Some(path) = new_path {
+                    if let Err(err) = self.open(&path) {
+                        error!(path = %path.display(), ?err, "Unable to open file: {err}");
+                    }
+                    if let Some(pos) = self.queue.current_position() {
+                        self.send_event(PlaybackEvent::QueuePositionChanged(pos));
+                    }
+                } else {
+                    self.stop();
+                }
+            }
+            DequeueManyResult::Unchanged => {}
         }
     }
 

--- a/src/playback/thread.rs
+++ b/src/playback/thread.rs
@@ -195,6 +195,7 @@ impl PlaybackThread {
                 PlaybackCommand::RemoveItem(idx) => self.remove(idx),
                 PlaybackCommand::RemoveItems(indices) => self.remove_many(&indices),
                 PlaybackCommand::MoveItem { from, to } => self.move_item(from, to),
+                PlaybackCommand::MoveItems { indices, to } => self.move_items(indices, to),
                 PlaybackCommand::Undo => self.undo(),
                 PlaybackCommand::SettingsChanged(settings) => self.settings_changed(settings),
                 PlaybackCommand::SetPositionBroadcastActive(active) => {
@@ -483,6 +484,20 @@ impl PlaybackThread {
                 self.send_event(PlaybackEvent::QueueUpdated);
             }
             MoveResult::Unchanged => {}
+        }
+    }
+
+    fn move_items(&mut self, indices: Vec<usize>, to: usize) {
+        use crate::playback::thread::queue_manager::MoveItemsResult;
+        match self.queue.move_items(indices, to) {
+            MoveItemsResult::Moved => {
+                self.send_event(PlaybackEvent::QueueUpdated);
+            }
+            MoveItemsResult::MovedCurrent { new_position } => {
+                self.send_event(PlaybackEvent::QueuePositionChanged(new_position));
+                self.send_event(PlaybackEvent::QueueUpdated);
+            }
+            MoveItemsResult::Unchanged => {}
         }
     }
 

--- a/src/playback/thread/queue_manager.rs
+++ b/src/playback/thread/queue_manager.rs
@@ -53,9 +53,7 @@ pub enum DequeueManyResult {
     /// Items were removed, queue position adjusted.
     Removed { new_position: usize },
     /// The currently playing item was removed.
-    RemovedCurrent {
-        new_path: Option<PathBuf>,
-    },
+    RemovedCurrent { new_path: Option<PathBuf> },
     /// Nothing changed (indices empty or all out of bounds).
     Unchanged,
 }
@@ -68,6 +66,13 @@ pub enum MoveResult {
         new_position: usize,
     },
     /// Nothing changed (same position or invalid).
+    Unchanged,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MoveItemsResult {
+    Moved,
+    MovedCurrent { new_position: usize },
     Unchanged,
 }
 
@@ -143,6 +148,12 @@ pub enum UndoAction {
     Moved {
         original: usize,
         new: usize,
+        previous_queue_next: usize,
+        previous_shuffle: bool,
+    },
+    MovedMany {
+        items: SmallVec<[(usize, QueueItemData); 2]>,
+        destination: usize,
         previous_queue_next: usize,
         previous_shuffle: bool,
     },
@@ -324,6 +335,31 @@ impl QueueManager {
 
                 let item = queue.remove(new);
                 queue.insert(original, item);
+
+                self.queue_next = previous_queue_next;
+                self.shuffle = previous_shuffle;
+
+                Self::undo_result_from_state(&queue, self.queue_next, self.shuffle)
+            }
+            Some(UndoAction::MovedMany {
+                items,
+                destination,
+                previous_queue_next,
+                previous_shuffle,
+            }) => {
+                let mut queue = self.queue.write().expect("poisoned queue lock");
+
+                for _ in 0..items.len() {
+                    if destination < queue.len() {
+                        queue.remove(destination);
+                    }
+                }
+
+                for (original_idx, item) in items {
+                    if original_idx <= queue.len() {
+                        queue.insert(original_idx, item);
+                    }
+                }
 
                 self.queue_next = previous_queue_next;
                 self.shuffle = previous_shuffle;
@@ -956,6 +992,101 @@ impl QueueManager {
         res
     }
 
+    /// Move multiple items to a single destination.
+    ///
+    /// Items at `indices` (sorted ascending) are removed, then re-inserted contiguously
+    /// starting at `to`. The destination `to` refers to the final position after removal
+    /// (i.e. the index where the first moved item should end up).
+    pub fn move_items(&mut self, mut indices: Vec<usize>, to: usize) -> MoveItemsResult {
+        if indices.is_empty() {
+            return MoveItemsResult::Unchanged;
+        }
+        if indices.len() == 1 {
+            let result = self.move_item(indices[0], to, true);
+            return match result {
+                MoveResult::Moved => MoveItemsResult::Moved,
+                MoveResult::MovedCurrent { new_position } => {
+                    MoveItemsResult::MovedCurrent { new_position }
+                }
+                MoveResult::Unchanged => MoveItemsResult::Unchanged,
+            };
+        }
+
+        let previous_queue_next = self.queue_next;
+        let previous_shuffle = self.shuffle;
+
+        let mut queue = self.queue.write().expect("poisoned queue lock");
+
+        indices.retain(|idx| *idx < queue.len());
+        indices.sort_unstable();
+        indices.dedup();
+
+        if indices.is_empty() {
+            drop(queue);
+            return MoveItemsResult::Unchanged;
+        }
+
+        // `to` is the insert position in the post-removal queue (the caller adjusts
+        // for additional removals beyond the primary source index)
+        let insert_at = to.min(queue.len() - indices.len());
+
+        // Record original positions and items, then remove in reverse order
+        let mut original_items: SmallVec<[(usize, QueueItemData); 2]> = SmallVec::new();
+        for &idx in indices.iter().rev() {
+            let item = queue.remove(idx);
+            original_items.push((idx, item));
+        }
+        // original_items is in reverse order, reverse to get ascending order
+        original_items.reverse();
+
+        // Insert all items at the destination
+        for (i, (_, item)) in original_items.iter().enumerate() {
+            queue.insert(insert_at + i, item.clone());
+        }
+
+        // Adjust current position
+        let res = if let Some(current) = previous_queue_next.checked_sub(1) {
+            if let Ok(current_offset) = indices.binary_search(&current) {
+                let new_position = insert_at + current_offset;
+                self.queue_next = new_position + 1;
+                MoveItemsResult::MovedCurrent { new_position }
+            } else {
+                let mut new_current = current;
+                for &idx in &indices {
+                    if idx < current {
+                        new_current = new_current.saturating_sub(1);
+                    }
+                }
+                if insert_at <= new_current {
+                    new_current += original_items.len();
+                }
+
+                if new_current != current {
+                    self.queue_next = new_current + 1;
+                    MoveItemsResult::MovedCurrent {
+                        new_position: new_current,
+                    }
+                } else {
+                    MoveItemsResult::Moved
+                }
+            }
+        } else {
+            MoveItemsResult::Moved
+        };
+
+        drop(queue);
+        self.persist_session_with_queue();
+
+        self.push_undo_action(UndoAction::MovedMany {
+            items: original_items,
+            destination: insert_at,
+            previous_queue_next,
+            previous_shuffle,
+        });
+
+        res
+    }
+
     /// Replace the entire queue with new items.
     ///
     /// If shuffle is enabled, the items are shuffled (but original order is preserved).
@@ -1153,7 +1284,7 @@ mod tests {
     use serde_json::json;
     use tokio::sync::watch;
 
-    use super::{DequeueManyResult, QueueManager, UndoResult};
+    use super::{DequeueManyResult, MoveItemsResult, QueueManager, UndoResult};
     use crate::{
         playback::{queue::QueueItemData, session_storage::PlaybackSessionData},
         settings::playback::PlaybackSettings,
@@ -1195,6 +1326,16 @@ mod tests {
             queue_next: manager.queue_next,
             shuffle: manager.shuffle,
         }
+    }
+
+    fn queue_ids(manager: &QueueManager) -> Vec<i64> {
+        manager
+            .queue
+            .read()
+            .expect("poisoned queue lock")
+            .iter()
+            .map(|item| item.get_db_id().expect("test items have db ids"))
+            .collect()
     }
 
     fn assert_undo_round_trip(manager: &mut QueueManager, before: QueueManagerState) {
@@ -1503,6 +1644,103 @@ mod tests {
         manager.dequeue_many(vec![0, 2]);
 
         assert_undo_round_trip(&mut manager, before);
+    }
+
+    #[test]
+    fn move_items_when_nothing_playing_does_not_start_playback() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5)]);
+        assert_eq!(manager.queue_next, 0);
+
+        let res = manager.move_items(vec![1, 3], 0);
+
+        assert!(matches!(res, MoveItemsResult::Moved));
+        assert_eq!(manager.queue_next, 0);
+        assert_eq!(queue_ids(&manager), vec![2, 4, 1, 3, 5]);
+    }
+
+    #[test]
+    fn move_items_keeps_relative_order_and_filters_duplicate_indices() {
+        let mut manager =
+            manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5), item(6)]);
+
+        let res = manager.move_items(vec![4, 1, 1, 99, 3], 0);
+
+        assert!(matches!(res, MoveItemsResult::Moved));
+        assert_eq!(queue_ids(&manager), vec![2, 4, 5, 1, 3, 6]);
+    }
+
+    #[test]
+    fn move_items_current_item_uses_its_offset_within_the_moved_block() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5)]);
+        manager.set_position(3); // current = index 3 (item 4)
+
+        let res = manager.move_items(vec![1, 3], 0);
+
+        assert_eq!(res, MoveItemsResult::MovedCurrent { new_position: 1 });
+        assert_eq!(manager.queue_next, 2);
+        assert_eq!(queue_ids(&manager), vec![2, 4, 1, 3, 5]);
+    }
+
+    #[test]
+    fn undo_move_items_restores_previous_state() {
+        let mut manager =
+            manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5), item(6)]);
+        manager.set_position(4);
+
+        let before = snapshot(&manager);
+
+        manager.move_items(vec![1, 3, 4], 0);
+
+        assert_undo_round_trip(&mut manager, before);
+    }
+
+    #[test]
+    fn undo_move_items_in_shuffle_mode_restores_previous_state() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5)]);
+        manager.set_position(2);
+        manager.toggle_shuffle();
+        manager.undo_stack.clear();
+
+        let before = snapshot(&manager);
+
+        manager.move_items(vec![0, 2], 1);
+
+        assert_undo_round_trip(&mut manager, before);
+    }
+
+    #[test]
+    fn move_items_all_after_current_leaves_position_unchanged() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5)]);
+        manager.set_position(1);
+        let before_queue_next = manager.queue_next;
+
+        let res = manager.move_items(vec![3, 4], 2);
+
+        assert_eq!(res, MoveItemsResult::Moved);
+        assert_eq!(manager.queue_next, before_queue_next);
+        assert_eq!(queue_ids(&manager), vec![1, 2, 4, 5, 3]);
+    }
+
+    #[test]
+    fn move_items_spanning_current_shifts_position() {
+        let mut manager =
+            manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5), item(6)]);
+        manager.set_position(2);
+
+        let res = manager.move_items(vec![0, 4], 1);
+
+        assert_eq!(res, MoveItemsResult::MovedCurrent { new_position: 3 });
+        assert_eq!(queue_ids(&manager), vec![2, 1, 5, 3, 4, 6]);
+    }
+
+    #[test]
+    fn move_items_clamps_destination_to_end() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5)]);
+
+        let res = manager.move_items(vec![0, 1], 99);
+
+        assert_eq!(res, MoveItemsResult::Moved);
+        assert_eq!(queue_ids(&manager), vec![3, 4, 5, 1, 2]);
     }
 
     #[test]

--- a/src/playback/thread/queue_manager.rs
+++ b/src/playback/thread/queue_manager.rs
@@ -48,6 +48,18 @@ pub enum DequeueResult {
     Unchanged,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum DequeueManyResult {
+    /// Items were removed, queue position adjusted.
+    Removed { new_position: usize },
+    /// The currently playing item was removed.
+    RemovedCurrent {
+        new_path: Option<PathBuf>,
+    },
+    /// Nothing changed (indices empty or all out of bounds).
+    Unchanged,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MoveResult {
     Moved,
@@ -820,6 +832,74 @@ impl QueueManager {
         res
     }
 
+    pub fn dequeue_many(&mut self, mut indices: Vec<usize>) -> DequeueManyResult {
+        if indices.is_empty() {
+            return DequeueManyResult::Unchanged;
+        }
+
+        let previous_queue_next = self.queue_next;
+        let previous_shuffle = self.shuffle;
+
+        let mut queue = self.queue.write().expect("poisoned queue lock");
+
+        indices.retain(|idx| *idx < queue.len());
+        indices.sort_unstable();
+        indices.dedup();
+
+        if indices.is_empty() {
+            return DequeueManyResult::Unchanged;
+        }
+
+        let mut removed_queue_items: SmallVec<[(usize, QueueItemData); 1]> = SmallVec::new();
+        let mut removed_original_items: SmallVec<[(usize, QueueItemData); 1]> = SmallVec::new();
+
+        for &idx in indices.iter().rev() {
+            let item = queue.remove(idx);
+
+            if self.shuffle
+                && let Some(pos) = self.original_queue.iter().position(|q| q == &item)
+            {
+                let orig_item = self.original_queue.remove(pos);
+                removed_original_items.push((pos, orig_item));
+            }
+
+            removed_queue_items.push((idx, item));
+        }
+
+        let current = self.queue_next.checked_sub(1);
+        let removed_current = current.is_some_and(|c| indices.binary_search(&c).is_ok());
+        let items_before_current = current
+            .map(|c| indices.iter().filter(|&&idx| idx < c).count())
+            .unwrap_or(0);
+
+        let res = if removed_current {
+            let current = current.expect("removed_current implies current is Some");
+            let new_path = Self::next_playable_from(&queue, current - items_before_current)
+                .and_then(|idx| queue.get(idx))
+                .map(|v| v.get_path().clone());
+            DequeueManyResult::RemovedCurrent { new_path }
+        } else if self.queue_next > 0 {
+            self.queue_next -= items_before_current;
+            DequeueManyResult::Removed {
+                new_position: self.queue_next - 1,
+            }
+        } else {
+            DequeueManyResult::Removed { new_position: 0 }
+        };
+
+        drop(queue);
+        self.persist_session_with_queue();
+
+        self.push_undo_action(UndoAction::Removed {
+            queue_items: removed_queue_items,
+            original_queue_items: removed_original_items,
+            previous_queue_next,
+            previous_shuffle,
+        });
+
+        res
+    }
+
     /// Move an item from one position to another. If it should be logged in the undo history, set
     /// `user_initiated` to `true`.
     pub fn move_item(&mut self, from: usize, to: usize, user_initiated: bool) -> MoveResult {
@@ -1073,7 +1153,7 @@ mod tests {
     use serde_json::json;
     use tokio::sync::watch;
 
-    use super::{QueueManager, UndoResult};
+    use super::{DequeueManyResult, QueueManager, UndoResult};
     use crate::{
         playback::{queue::QueueItemData, session_storage::PlaybackSessionData},
         settings::playback::PlaybackSettings,
@@ -1299,6 +1379,128 @@ mod tests {
         let before = snapshot(&manager);
 
         manager.clear(false);
+
+        assert_undo_round_trip(&mut manager, before);
+    }
+
+    #[test]
+    fn dequeue_many_empty_indices_is_unchanged() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3)]);
+        manager.set_position(1);
+        let before = snapshot(&manager);
+
+        let res = manager.dequeue_many(vec![]);
+
+        assert!(matches!(res, DequeueManyResult::Unchanged));
+        assert_eq!(snapshot(&manager), before);
+    }
+
+    #[test]
+    fn dequeue_many_out_of_bounds_indices_are_filtered() {
+        let mut manager = manager_with_queue(vec![item(1), item(2)]);
+        manager.set_position(1);
+        let before = snapshot(&manager);
+
+        let res = manager.dequeue_many(vec![5, 6, 7]);
+
+        assert!(matches!(res, DequeueManyResult::Unchanged));
+        assert_eq!(snapshot(&manager), before);
+    }
+
+    #[test]
+    fn dequeue_many_when_nothing_playing_does_not_start_playback() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3)]);
+        // queue_next stays 0 (nothing playing).
+        assert_eq!(manager.queue_next, 0);
+
+        let res = manager.dequeue_many(vec![0, 1]);
+
+        match res {
+            DequeueManyResult::Removed { new_position } => assert_eq!(new_position, 0),
+            other => panic!("expected Removed, got {other:?}"),
+        }
+        assert_eq!(manager.queue_next, 0);
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn dequeue_many_removes_current_item() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4)]);
+        manager.set_position(1); // current = index 1 (item 2)
+
+        let res = manager.dequeue_many(vec![1, 3]);
+
+        // new_path depends on files existing on disk; just assert the variant.
+        assert!(matches!(res, DequeueManyResult::RemovedCurrent { .. }));
+        assert_eq!(manager.len(), 2);
+    }
+
+    #[test]
+    fn dequeue_many_removes_items_before_current_shifts_position() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5)]);
+        manager.set_position(3); // current = index 3 (item 4)
+
+        let res = manager.dequeue_many(vec![0, 1]);
+
+        match res {
+            DequeueManyResult::Removed { new_position } => assert_eq!(new_position, 1),
+            other => panic!("expected Removed, got {other:?}"),
+        }
+        // current item (item 4) is now at index 1; queue_next points past it.
+        assert_eq!(manager.queue_next, 2);
+    }
+
+    #[test]
+    fn dequeue_many_removes_items_after_current_keeps_position() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5)]);
+        manager.set_position(1); // current = index 1 (item 2)
+        let before_queue_next = manager.queue_next;
+
+        let res = manager.dequeue_many(vec![3, 4]);
+
+        match res {
+            DequeueManyResult::Removed { new_position } => assert_eq!(new_position, 1),
+            other => panic!("expected Removed, got {other:?}"),
+        }
+        assert_eq!(manager.queue_next, before_queue_next);
+    }
+
+    #[test]
+    fn dequeue_many_deduplicates_indices() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3)]);
+        manager.set_position(0);
+
+        let res = manager.dequeue_many(vec![2, 2, 2]);
+
+        match res {
+            DequeueManyResult::Removed { new_position } => assert_eq!(new_position, 0),
+            other => panic!("expected Removed, got {other:?}"),
+        }
+        assert_eq!(manager.len(), 2);
+    }
+
+    #[test]
+    fn undo_dequeue_many_restores_previous_state() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4), item(5)]);
+        manager.set_position(2);
+
+        let before = snapshot(&manager);
+
+        manager.dequeue_many(vec![0, 2, 4]);
+
+        assert_undo_round_trip(&mut manager, before);
+    }
+
+    #[test]
+    fn undo_dequeue_many_in_shuffle_mode_restores_original_queue() {
+        let mut manager = manager_with_queue(vec![item(1), item(2), item(3), item(4)]);
+        manager.set_position(1);
+        manager.toggle_shuffle();
+        manager.undo_stack.clear();
+
+        let before = snapshot(&manager);
+
+        manager.dequeue_many(vec![0, 2]);
 
         assert_undo_round_trip(&mut manager, before);
     }

--- a/src/ui/components/drag_drop.rs
+++ b/src/ui/components/drag_drop.rs
@@ -17,6 +17,7 @@ pub enum DropPosition {
 #[derive(Clone, Debug)]
 pub struct DragData {
     pub source_index: usize,
+    pub additional_indices: Vec<usize>,
     pub list_id: ElementId,
 }
 
@@ -24,8 +25,22 @@ impl DragData {
     pub fn new(source_index: usize, list_id: impl Into<ElementId>) -> Self {
         Self {
             source_index,
+            additional_indices: Vec::new(),
             list_id: list_id.into(),
         }
+    }
+
+    pub fn with_additional_indices(mut self, indices: Vec<usize>) -> Self {
+        self.additional_indices = indices;
+        self
+    }
+
+    pub fn all_indices(&self) -> Vec<usize> {
+        let mut all = vec![self.source_index];
+        all.extend_from_slice(&self.additional_indices);
+        all.sort_unstable();
+        all.dedup();
+        all
     }
 }
 
@@ -115,7 +130,7 @@ impl Default for EdgeScrollConfig {
 
 #[derive(Clone, Debug, Default)]
 pub struct DragDropState {
-    pub dragging_index: Option<usize>,
+    pub dragging_indices: Vec<usize>,
     /// Current drop target: (index, position)
     pub drop_target: Option<(usize, DropPosition)>,
     pub is_dragging: bool,
@@ -136,7 +151,7 @@ impl DragDropState {
     }
 
     pub fn end_drag(&mut self) {
-        self.dragging_index = None;
+        self.dragging_indices.clear();
         self.is_dragging = false;
         self.drop_target = None;
         self.drag_mouse_y = None;
@@ -178,7 +193,7 @@ impl DragDropItemState {
     pub fn for_index(manager: &DragDropListManager, index: usize) -> Self {
         let state = &manager.state;
 
-        let is_being_dragged = state.dragging_index == Some(index);
+        let is_being_dragged = state.dragging_indices.contains(&index);
 
         let (is_drop_target_before, is_drop_target_after) =
             if let Some((target_idx, position)) = state.drop_target {
@@ -439,13 +454,13 @@ pub fn handle_drag_move<V: 'static>(
         return false;
     }
 
+    let all_indices = drag_data.all_indices();
     let mouse_pos = event.event.position;
     let container_bounds = event.bounds;
-    let source_index = drag_data.source_index;
 
     manager.update(cx, |m, _| {
         m.state.is_dragging = true;
-        m.state.dragging_index = Some(source_index);
+        m.state.dragging_indices = all_indices;
         m.state.set_mouse_y(mouse_pos.y);
         m.container_bounds = Some(container_bounds);
     });
@@ -516,7 +531,7 @@ pub fn handle_track_drag_move<V: 'static>(
 
     manager.update(cx, |m, _| {
         m.state.is_dragging = true;
-        m.state.dragging_index = Some(source_index);
+        m.state.dragging_indices = vec![source_index];
         m.state.set_mouse_y(mouse_pos.y);
         m.container_bounds = Some(container_bounds);
     });
@@ -575,6 +590,37 @@ pub fn handle_drop<V: 'static, F>(
 
         if source_index != final_target {
             on_reorder(source_index, final_target, cx);
+        }
+    }
+
+    manager.update(cx, |m, _| m.state.end_drag());
+}
+
+/// Handle a drop of DragData with potential multi-selection indices.
+/// Like `handle_drop`, but calls `on_multi_reorder` with the full DragData
+/// so the caller can dispatch single vs. multi-item moves.
+pub fn handle_drop_multi<V: 'static, F>(
+    manager: Entity<DragDropListManager>,
+    drag_data: &DragData,
+    cx: &mut Context<V>,
+    on_multi_reorder: F,
+) where
+    F: FnOnce(&DragData, usize, &mut Context<V>),
+{
+    let config_list_id = manager.read(cx).config.list_id.clone();
+
+    if drag_data.list_id != config_list_id {
+        return;
+    }
+
+    let target = manager.read(cx).state.drop_target;
+
+    if let Some((target_index, position)) = target {
+        let final_target = calculate_move_target(drag_data.source_index, target_index, position);
+
+        let is_multi = !drag_data.additional_indices.is_empty();
+        if is_multi || drag_data.source_index != final_target {
+            on_multi_reorder(drag_data, final_target, cx);
         }
     }
 

--- a/src/ui/library/add_to_playlist.rs
+++ b/src/ui/library/add_to_playlist.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use cntp_i18n::tr;
 use gpui::{
@@ -24,29 +24,77 @@ use crate::{
     },
 };
 
-// i64 here is the track ID
-impl PaletteItem for (i64, Playlist) {
+#[derive(Clone, Debug, PartialEq)]
+enum TrackList {
+    Single(i64),
+    Multi(Vec<i64>),
+}
+
+impl TrackList {
+    fn from_ids(ids: Vec<i64>) -> Self {
+        if ids.len() == 1 {
+            TrackList::Single(ids[0])
+        } else {
+            TrackList::Multi(ids)
+        }
+    }
+
+    fn first(&self) -> i64 {
+        match self {
+            TrackList::Single(id) => *id,
+            TrackList::Multi(ids) => ids[0],
+        }
+    }
+
+    fn is_multi(&self) -> bool {
+        matches!(self, TrackList::Multi(ids) if ids.len() > 1)
+    }
+
+    fn ids(&self) -> &[i64] {
+        match self {
+            TrackList::Single(id) => std::slice::from_ref(id),
+            TrackList::Multi(ids) => ids,
+        }
+    }
+}
+
+type SharedTrackList = Arc<RwLock<TrackList>>;
+
+fn read_track_list(shared: &SharedTrackList) -> TrackList {
+    shared.read().expect("poisoned track_list lock").clone()
+}
+
+impl PaletteItem for (TrackList, Playlist) {
     fn left_content(&self, cx: &mut App) -> Option<FinderItemLeft> {
         self.1.left_content(cx)
     }
 
     fn middle_content(&self, cx: &mut App) -> SharedString {
-        let has_track = cx.playlist_has_track(self.1.id, self.0).ok().flatten();
-
-        if has_track.is_none() {
+        if self.0.is_multi() {
             tr!(
                 "ADD_TO_SELECTED_PLAYLIST",
-                "Add to {{name}}",
                 name = self.1.name.0.as_str()
             )
             .into()
         } else {
-            tr!(
-                "REMOVE_FROM_SELECTED_PLAYLIST",
-                "Remove from {{name}}",
-                name = self.1.name.0.as_str()
-            )
-            .into()
+            let track_id = self.0.first();
+            let has_track = cx.playlist_has_track(self.1.id, track_id).ok().flatten();
+
+            if has_track.is_none() {
+                tr!(
+                    "ADD_TO_SELECTED_PLAYLIST",
+                    "Add to {{name}}",
+                    name = self.1.name.0.as_str()
+                )
+                .into()
+            } else {
+                tr!(
+                    "REMOVE_FROM_SELECTED_PLAYLIST",
+                    "Remove from {{name}}",
+                    name = self.1.name.0.as_str()
+                )
+                .into()
+            }
         }
     }
 
@@ -55,29 +103,35 @@ impl PaletteItem for (i64, Playlist) {
     }
 }
 
-type MatcherFunc = Box<dyn Fn(&Arc<(i64, Playlist)>, &mut App) -> Utf32String + 'static>;
-type OnAccept = Box<dyn Fn(&Arc<(i64, Playlist)>, &mut App) + 'static>;
+type MatcherFunc = Box<dyn Fn(&Arc<(TrackList, Playlist)>, &mut App) -> Utf32String + 'static>;
+type OnAccept = Box<dyn Fn(&Arc<(TrackList, Playlist)>, &mut App) + 'static>;
 
 pub struct AddToPlaylist {
     show: Entity<bool>,
-    palette: Entity<Palette<(i64, Playlist), MatcherFunc, OnAccept>>,
+    palette: Entity<Palette<(TrackList, Playlist), MatcherFunc, OnAccept>>,
+    track_list: SharedTrackList,
 }
 
 impl AddToPlaylist {
-    pub fn new(cx: &mut App, show: Entity<bool>, track_id: i64) -> Entity<Self> {
+    pub fn new(cx: &mut App, show: Entity<bool>, track_ids: Vec<i64>) -> Entity<Self> {
         cx.new(|cx| {
+            let track_list: SharedTrackList =
+                Arc::new(RwLock::new(TrackList::from_ids(track_ids)));
+
+            let track_list_for_observe = track_list.clone();
             cx.observe(&show, move |this: &mut Self, _, cx| {
-                this.palette.update(cx, |this, cx| {
+                let current = read_track_list(&track_list_for_observe);
+                this.palette.update(cx, |palette, cx| {
                     let new_playlists = (*cx.get_all_playlists().unwrap())
                         .clone()
                         .into_iter()
-                        .map(|playlist| (track_id, playlist))
+                        .map(|playlist| (current.clone(), playlist))
                         .map(Arc::new)
                         .collect::<Vec<_>>();
 
                     cx.emit(new_playlists);
 
-                    this.reset(cx);
+                    palette.reset(cx);
                 });
 
                 cx.notify();
@@ -89,57 +143,93 @@ impl AddToPlaylist {
             let show_clone = show.clone();
 
             let on_accept: OnAccept = Box::new(move |playlist, cx| {
-                let has_track = cx
-                    .playlist_has_track(playlist.1.id, track_id)
-                    .ok()
-                    .flatten();
-
-                let pool = cx.global::<Pool>().0.clone();
-                let playlist_tracker = cx.global::<Models>().playlist_tracker.clone();
+                let track_ids = playlist.0.ids().to_vec();
                 let playlist_id = playlist.1.id;
 
-                cx.spawn(async move |cx| {
-                    let task = if let Some(id) = has_track {
-                        crate::RUNTIME
-                            .spawn(async move { db::remove_playlist_item(&pool, id).await })
-                    } else {
-                        crate::RUNTIME.spawn(async move {
-                            db::add_playlist_item(&pool, playlist_id, track_id)
-                                .await
-                                .map(|_| ())
-                        })
-                    };
+                if track_ids.len() == 1 {
+                    let track_id = track_ids[0];
+                    let has_track = cx
+                        .playlist_has_track(playlist_id, track_id)
+                        .ok()
+                        .flatten();
 
-                    match task.await {
-                        Ok(Ok(())) => {}
-                        Ok(Err(err)) => {
-                            error!("could not remove/add track from playlist: {err:?}");
-                            return;
-                        }
-                        Err(err) => {
-                            error!("remove/add from playlist task panicked: {err:?}");
-                            return;
-                        }
-                    }
+                    let pool = cx.global::<Pool>().0.clone();
+                    let playlist_tracker = cx.global::<Models>().playlist_tracker.clone();
 
-                    playlist_tracker.update(cx, |_, cx| {
-                        cx.emit(PlaylistEvent::PlaylistUpdated(playlist_id));
-                    });
-                })
-                .detach();
+                    cx.spawn(async move |cx| {
+                        let task = if let Some(id) = has_track {
+                            crate::RUNTIME
+                                .spawn(async move { db::remove_playlist_item(&pool, id).await })
+                        } else {
+                            crate::RUNTIME.spawn(async move {
+                                db::add_playlist_item(&pool, playlist_id, track_id)
+                                    .await
+                                    .map(|_| ())
+                            })
+                        };
+
+                        match task.await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(err)) => {
+                                error!("could not remove/add track from playlist: {err:?}");
+                                return;
+                            }
+                            Err(err) => {
+                                error!("remove/add from playlist task panicked: {err:?}");
+                                return;
+                            }
+                        }
+
+                        playlist_tracker.update(cx, |_, cx| {
+                            cx.emit(PlaylistEvent::PlaylistUpdated(playlist_id));
+                        });
+                    })
+                    .detach();
+                } else {
+                    let pool = cx.global::<Pool>().0.clone();
+                    let playlist_tracker = cx.global::<Models>().playlist_tracker.clone();
+
+                    cx.spawn(async move |cx| {
+                        let task = crate::RUNTIME.spawn(async move {
+                            for track_id in &track_ids {
+                                db::add_playlist_item(&pool, playlist_id, *track_id).await?;
+                            }
+                            Ok::<(), sqlx::Error>(())
+                        });
+
+                        match task.await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(err)) => {
+                                error!("could not add tracks to playlist: {err:?}");
+                                return;
+                            }
+                            Err(err) => {
+                                error!("add tracks to playlist task panicked: {err:?}");
+                                return;
+                            }
+                        }
+
+                        playlist_tracker.update(cx, |_, cx| {
+                            cx.emit(PlaylistEvent::PlaylistUpdated(playlist_id));
+                        });
+                    })
+                    .detach();
+                }
 
                 show_clone.write(cx, false);
             });
 
+            let initial_track_list = read_track_list(&track_list);
             let items = (*cx.get_all_playlists().unwrap())
                 .clone()
                 .into_iter()
-                .map(|playlist| (track_id, playlist))
+                .map(|playlist| (initial_track_list.clone(), playlist))
                 .map(Arc::new)
                 .collect();
 
             let palette = Palette::new(cx, items, matcher, on_accept, &show);
 
+            let track_list_for_create = track_list.clone();
             let show_for_create = show.clone();
             let provider: ExtraItemProvider = Arc::new(move |query: &str| {
                 let name = query.trim();
@@ -151,6 +241,7 @@ impl AddToPlaylist {
                 let display = tr!("CREATE_PLAYLIST", name = name_string);
 
                 let show_clone2 = show_for_create.clone();
+                let create_track_ids = read_track_list(&track_list_for_create).ids().to_vec();
 
                 vec![ExtraItem {
                     left: Some(FinderItemLeft::Icon(PLAYLIST_ADD.into())),
@@ -160,11 +251,14 @@ impl AddToPlaylist {
                         let pool = cx.global::<Pool>().0.clone();
                         let playlist_tracker = cx.global::<Models>().playlist_tracker.clone();
                         let name_string = name_string.clone();
+                        let create_track_ids = create_track_ids.clone();
 
                         cx.spawn(async move |cx| {
                             let task = crate::RUNTIME.spawn(async move {
                                 let playlist_id = db::create_playlist(&pool, &name_string).await?;
-                                db::add_playlist_item(&pool, playlist_id, track_id).await?;
+                                for track_id in &create_track_ids {
+                                    db::add_playlist_item(&pool, playlist_id, *track_id).await?;
+                                }
                                 Ok::<i64, sqlx::Error>(playlist_id)
                             });
 
@@ -197,8 +291,17 @@ impl AddToPlaylist {
                 palette.register_extra_provider(provider.clone(), cx);
             });
 
-            Self { show, palette }
+            Self {
+                show,
+                palette,
+                track_list,
+            }
         })
+    }
+
+    pub fn set_track_ids(&self, track_ids: Vec<i64>) {
+        *self.track_list.write().expect("poisoned track_list lock") =
+            TrackList::from_ids(track_ids);
     }
 }
 

--- a/src/ui/library/add_to_playlist.rs
+++ b/src/ui/library/add_to_playlist.rs
@@ -71,11 +71,7 @@ impl PaletteItem for (TrackList, Playlist) {
 
     fn middle_content(&self, cx: &mut App) -> SharedString {
         if self.0.is_multi() {
-            tr!(
-                "ADD_TO_SELECTED_PLAYLIST",
-                name = self.1.name.0.as_str()
-            )
-            .into()
+            tr!("ADD_TO_SELECTED_PLAYLIST", name = self.1.name.0.as_str()).into()
         } else {
             let track_id = self.0.first();
             let has_track = cx.playlist_has_track(self.1.id, track_id).ok().flatten();
@@ -115,8 +111,7 @@ pub struct AddToPlaylist {
 impl AddToPlaylist {
     pub fn new(cx: &mut App, show: Entity<bool>, track_ids: Vec<i64>) -> Entity<Self> {
         cx.new(|cx| {
-            let track_list: SharedTrackList =
-                Arc::new(RwLock::new(TrackList::from_ids(track_ids)));
+            let track_list: SharedTrackList = Arc::new(RwLock::new(TrackList::from_ids(track_ids)));
 
             let track_list_for_observe = track_list.clone();
             cx.observe(&show, move |this: &mut Self, _, cx| {
@@ -148,10 +143,7 @@ impl AddToPlaylist {
 
                 if track_ids.len() == 1 {
                     let track_id = track_ids[0];
-                    let has_track = cx
-                        .playlist_has_track(playlist_id, track_id)
-                        .ok()
-                        .flatten();
+                    let has_track = cx.playlist_has_track(playlist_id, track_id).ok().flatten();
 
                     let pool = cx.global::<Pool>().0.clone();
                     let playlist_tracker = cx.global::<Models>().playlist_tracker.clone();

--- a/src/ui/library/context_menus.rs
+++ b/src/ui/library/context_menus.rs
@@ -72,7 +72,7 @@ pub(crate) fn add_to_playlist_state(
 ) -> (Entity<bool>, Entity<AddToPlaylist>) {
     let menu_state = window.use_keyed_state((key, track_id as usize), cx, |_, cx| {
         let show = cx.new(|_| false);
-        let add_to = AddToPlaylist::new(cx, show.clone(), track_id);
+        let add_to = AddToPlaylist::new(cx, show.clone(), vec![track_id]);
         AddToPlaylistState { show, add_to }
     });
     let state = menu_state.read(cx);

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -24,7 +24,7 @@ use crate::{
         library::{ViewSwitchMessage, add_to_playlist::AddToPlaylist},
     },
 };
-use cntp_i18n::tr;
+use cntp_i18n::{tr, trn};
 use gpui::*;
 use prelude::FluentBuilder;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -526,10 +526,11 @@ impl Render for QueueItem {
                         .item(menu_item(
                             "remove_items",
                             Some(CROSS),
-                            tr!(
+                            trn!(
                                 "REMOVE_N_FROM_QUEUE",
-                                "Remove {{count}} from queue",
-                                count = remove_count as isize
+                                "Remove {{count}} track from queue",
+                                "Remove {{count}} tracks from queue",
+                                count = remove_count
                             ),
                             move |_, _, cx| {
                                 cx.global::<PlaybackInterface>()

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -33,7 +33,7 @@ use super::{
     components::button::{ButtonSize, ButtonStyle, button},
     models::{
         HasLikedState, LIKED_SONGS_PLAYLIST_ID, Models, PlaybackInfo, subscribe_liked_updates,
-        toggle_like,
+        toggle_like, toggle_like_by_id,
     },
     scroll_follow::SmoothScrollFollow,
     theme::Theme,
@@ -196,7 +196,7 @@ impl QueueItem {
 
             let show_add_to = cx.new(|_| false);
             let add_to =
-                track_id.map(|track_id| AddToPlaylist::new(cx, show_add_to.clone(), track_id));
+                track_id.map(|track_id| AddToPlaylist::new(cx, show_add_to.clone(), vec![track_id]));
 
             let is_liked = track_id.and_then(|id| {
                 cx.playlist_has_track(LIKED_SONGS_PLAYLIST_ID, id)
@@ -255,6 +255,27 @@ impl Render for QueueItem {
             let idx = self.idx;
             let current = self.current;
             let selection = self.selection.clone();
+            let selection_for_aux = selection.clone();
+            let selection_read = selection.read(cx);
+            let is_multi_selected = selection_read.is_multi() && selection_read.contains(idx);
+            let selected_indices = if is_multi_selected {
+                selection_read.indices()
+            } else {
+                Vec::new()
+            };
+            let single_track_id = self.track_id;
+            let queue_item_entity = cx.entity().clone();
+
+            let selected_track_ids: Vec<i64> = if is_multi_selected {
+                let queue = cx.global::<Models>().queue.read(cx);
+                let queue_data = queue.data.read().expect("could not read queue");
+                selected_indices
+                    .iter()
+                    .filter_map(|&i| queue_data.get(i).and_then(|item| item.get_db_id()))
+                    .collect()
+            } else {
+                self.track_id.into_iter().collect()
+            };
 
             let item_state =
                 DragDropItemState::for_index(self.drag_drop_manager.read(cx), self.idx);
@@ -326,6 +347,11 @@ impl Render for QueueItem {
                             .drag_over::<DragData>(
                                 move |style, _, _, _| style.bg(gpui::rgba(0x88888822)),
                             )
+                        })
+                        .on_aux_click(move |ev: &ClickEvent, _, cx| {
+                            if ev.is_right_click() && !selection_for_aux.read(cx).contains(idx) {
+                                selection_for_aux.update(cx, |s, cx| s.select(idx, cx));
+                            }
                         })
                         .when_some(self.add_to.clone(), |this, that| this.child(that))
                         .child(DropIndicator::with_state(
@@ -403,83 +429,187 @@ impl Render for QueueItem {
                         ),
                 )
                 .child(
-                    menu()
-                        .when(self.add_to.is_some(), |menu| {
-                            menu.item(
-                                menu_item(
-                                    "go_to_album",
-                                    Some(DISC),
-                                    tr!("GO_TO_ALBUM", "Go to album"),
-                                    move |_, _, cx| {
-                                        if let Some(album_id) = album_id {
-                                            let switcher =
-                                                cx.global::<Models>().switcher_model.clone();
-                                            switcher.update(cx, |_, cx| {
-                                                cx.emit(ViewSwitchMessage::Release(album_id, None));
-                                            })
-                                        }
-                                    },
-                                )
-                                .disabled(!is_available),
-                            )
-                            .item(
-                                menu_item(
-                                    "go_to_artist",
-                                    Some(USERS),
-                                    tr!("GO_TO_ARTIST", "Go to artist"),
-                                    move |_, _, cx| {
-                                        if let Some(album_id) = album_id {
-                                            let Ok(artist_id) = cx.artist_id_for_album(album_id)
-                                            else {
-                                                return;
-                                            };
+                    if is_multi_selected {
+                        let remove_indices = selected_indices.clone();
+                        let remove_count = selected_indices.len();
+                        let add_to_ids = selected_track_ids.clone();
+                        let entity_for_add = queue_item_entity.clone();
+                        let show_add_to_multi = self.show_add_to.clone();
 
-                                            let switcher =
-                                                cx.global::<Models>().switcher_model.clone();
-                                            switcher.update(cx, |_, cx| {
-                                                cx.emit(ViewSwitchMessage::Artist(artist_id));
-                                            })
+                        let liked_ids: Vec<i64> = selected_track_ids
+                            .iter()
+                            .copied()
+                            .filter(|id| {
+                                cx.playlist_has_track(LIKED_SONGS_PLAYLIST_ID, *id)
+                                    .ok()
+                                    .flatten()
+                                    .is_some()
+                            })
+                            .collect();
+                        let any_liked = !liked_ids.is_empty();
+
+                        menu()
+                            .when(!add_to_ids.is_empty(), |menu| {
+                                menu.item(menu_item(
+                                    "add_to_playlist",
+                                    Some(PLAYLIST_ADD),
+                                    tr!("ADD_TO_PLAYLIST"),
+                                    move |_, _, cx| {
+                                        entity_for_add.update(cx, |item, cx| {
+                                            match &item.add_to {
+                                                Some(add_to) => {
+                                                    add_to.read(cx).set_track_ids(add_to_ids.clone());
+                                                }
+                                                None => {
+                                                    item.add_to = Some(AddToPlaylist::new(
+                                                        cx,
+                                                        item.show_add_to.clone(),
+                                                        add_to_ids.clone(),
+                                                    ));
+                                                }
+                                            }
+                                        });
+                                        show_add_to_multi.write(cx, true);
+                                    },
+                                ))
+                                .item(menu_separator())
+                            })
+                            .when(!selected_track_ids.is_empty(), |menu| {
+                                let track_ids_for_like = selected_track_ids.clone();
+                                let liked_ids = liked_ids.clone();
+                                menu.item(menu_item(
+                                    "toggle_like",
+                                    Some(if any_liked { STAR_FILLED } else { STAR }),
+                                    if any_liked { tr!("UNLIKE") } else { tr!("LIKE") },
+                                    move |_, _, cx| {
+                                        if any_liked {
+                                            for &track_id in &liked_ids {
+                                                let is_liked = cx
+                                                    .playlist_has_track(LIKED_SONGS_PLAYLIST_ID, track_id)
+                                                    .ok()
+                                                    .flatten();
+                                                if is_liked.is_some() {
+                                                    toggle_like_by_id(track_id, is_liked, cx);
+                                                }
+                                            }
+                                        } else {
+                                            for &track_id in &track_ids_for_like {
+                                                toggle_like_by_id(track_id, None, cx);
+                                            }
                                         }
                                     },
-                                )
-                                .disabled(!is_available),
-                            )
-                            .item(menu_separator())
+                                ))
+                                .item(menu_separator())
+                            })
                             .item(menu_item(
-                                "add_to_playlist",
-                                Some(PLAYLIST_ADD),
-                                tr!("ADD_TO_PLAYLIST"),
+                                "remove_items",
+                                Some(CROSS),
+                                tr!(
+                                    "REMOVE_N_FROM_QUEUE",
+                                    "Remove {{count}} from queue",
+                                    count = remove_count as isize
+                                ),
                                 move |_, _, cx| {
-                                    show_add_to.write(cx, true);
+                                    cx.global::<PlaybackInterface>()
+                                        .remove_items(remove_indices.clone());
                                 },
                             ))
-                            .item(menu_separator())
-                            .when_some(self.track_id, |menu, track_id| {
-                                let entity = cx.entity().clone();
-                                let is_liked = self.is_liked.is_some();
+                    } else {
+                        let entity_for_add = queue_item_entity.clone();
+                        menu()
+                            .when(self.add_to.is_some(), |menu| {
                                 menu.item(
                                     menu_item(
-                                        "toggle_like",
-                                        Some(if is_liked { STAR_FILLED } else { STAR }),
-                                        if is_liked { tr!("UNLIKE") } else { tr!("LIKE") },
+                                        "go_to_album",
+                                        Some(DISC),
+                                        tr!("GO_TO_ALBUM", "Go to album"),
                                         move |_, _, cx| {
-                                            toggle_like(track_id, entity.clone(), cx);
+                                            if let Some(album_id) = album_id {
+                                                let switcher =
+                                                    cx.global::<Models>().switcher_model.clone();
+                                                switcher.update(cx, |_, cx| {
+                                                    cx.emit(ViewSwitchMessage::Release(album_id, None));
+                                                })
+                                            }
                                         },
                                     )
                                     .disabled(!is_available),
                                 )
+                                .item(
+                                    menu_item(
+                                        "go_to_artist",
+                                        Some(USERS),
+                                        tr!("GO_TO_ARTIST", "Go to artist"),
+                                        move |_, _, cx| {
+                                            if let Some(album_id) = album_id {
+                                                let Ok(artist_id) = cx.artist_id_for_album(album_id)
+                                                else {
+                                                    return;
+                                                };
+
+                                                let switcher =
+                                                    cx.global::<Models>().switcher_model.clone();
+                                                switcher.update(cx, |_, cx| {
+                                                    cx.emit(ViewSwitchMessage::Artist(artist_id));
+                                                })
+                                            }
+                                        },
+                                    )
+                                    .disabled(!is_available),
+                                )
+                                .item(menu_separator())
+                                .item(menu_item(
+                                    "add_to_playlist",
+                                    Some(PLAYLIST_ADD),
+                                    tr!("ADD_TO_PLAYLIST"),
+                                    move |_, _, cx| {
+                                        if let Some(track_id) = single_track_id {
+                                            entity_for_add.update(cx, |item, cx| {
+                                                match &item.add_to {
+                                                    Some(add_to) => {
+                                                        add_to.read(cx).set_track_ids(vec![track_id]);
+                                                    }
+                                                    None => {
+                                                        item.add_to = Some(AddToPlaylist::new(
+                                                            cx,
+                                                            item.show_add_to.clone(),
+                                                            vec![track_id],
+                                                        ));
+                                                    }
+                                                }
+                                            });
+                                        }
+                                        show_add_to.write(cx, true);
+                                    },
+                                ))
+                                .item(menu_separator())
+                                .when_some(self.track_id, |menu, track_id| {
+                                    let entity = cx.entity().clone();
+                                    let is_liked = self.is_liked.is_some();
+                                    menu.item(
+                                        menu_item(
+                                            "toggle_like",
+                                            Some(if is_liked { STAR_FILLED } else { STAR }),
+                                            if is_liked { tr!("UNLIKE") } else { tr!("LIKE") },
+                                            move |_, _, cx| {
+                                                toggle_like(track_id, entity.clone(), cx);
+                                            },
+                                        )
+                                        .disabled(!is_available),
+                                    )
+                                })
+                                .item(menu_separator())
                             })
-                            .item(menu_separator())
-                        })
-                        .item(menu_item(
-                            "remove_item",
-                            Some(CROSS),
-                            tr!("REMOVE_FROM_QUEUE", "Remove from queue"),
-                            move |_, _, cx| {
-                                let playback = cx.global::<PlaybackInterface>();
-                                playback.remove_item(idx);
-                            },
-                        )),
+                            .item(menu_item(
+                                "remove_item",
+                                Some(CROSS),
+                                tr!("REMOVE_FROM_QUEUE", "Remove from queue"),
+                                move |_, _, cx| {
+                                    let playback = cx.global::<PlaybackInterface>();
+                                    playback.remove_item(idx);
+                                },
+                            ))
+                    },
                 )
                 .into_any_element()
         } else {

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -11,7 +11,8 @@ use crate::{
                 AlbumDragData, DragData, DragDropItemState, DragDropListConfig,
                 DragDropListManager, DragPreview, DropIndicator, TrackDragData,
                 calculate_drop_target, check_drag_cancelled, continue_edge_scroll,
-                get_edge_scroll_direction, handle_drag_move, handle_drop, perform_edge_scroll,
+                get_edge_scroll_direction, handle_drag_move, handle_drop_multi,
+                perform_edge_scroll,
             },
             icons::{CROSS, DISC, PLAYLIST_ADD, STAR, STAR_FILLED, TRASH, USERS, icon},
             managed_image::{ManagedImageKey, managed_image},
@@ -67,10 +68,6 @@ impl QueueSelection {
 
     pub fn is_multi(&self) -> bool {
         self.selected.len() > 1
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.selected.is_empty()
     }
 
     pub fn indices(&self) -> Vec<usize> {
@@ -195,8 +192,8 @@ impl QueueItem {
             .detach();
 
             let show_add_to = cx.new(|_| false);
-            let add_to =
-                track_id.map(|track_id| AddToPlaylist::new(cx, show_add_to.clone(), vec![track_id]));
+            let add_to = track_id
+                .map(|track_id| AddToPlaylist::new(cx, show_add_to.clone(), vec![track_id]));
 
             let is_liked = track_id.and_then(|id| {
                 cx.playlist_has_track(LIKED_SONGS_PLAYLIST_ID, id)
@@ -255,6 +252,7 @@ impl Render for QueueItem {
             let idx = self.idx;
             let current = self.current;
             let selection = self.selection.clone();
+            let selection_for_drag = selection.clone();
             let selection_for_aux = selection.clone();
             let selection_read = selection.read(cx);
             let is_multi_selected = selection_read.is_multi() && selection_read.contains(idx);
@@ -310,9 +308,10 @@ impl Render for QueueItem {
                         .when(is_selected && !item_state.is_being_dragged, |div| {
                             div.bg(theme.queue_item_selected)
                         })
-                        .when(!is_selected && is_current && !item_state.is_being_dragged, |div| {
-                            div.bg(theme.queue_item_current)
-                        })
+                        .when(
+                            !is_selected && is_current && !item_state.is_being_dragged,
+                            |div| div.bg(theme.queue_item_current),
+                        )
                         .when(is_available, |div| {
                             div.on_click(move |event: &ClickEvent, _, cx| {
                                 cx.stop_propagation();
@@ -324,24 +323,43 @@ impl Render for QueueItem {
                                 } else if ctrl {
                                     selection.update(cx, |s, cx| s.ctrl_toggle(idx, cx));
                                 } else if modifiers.shift {
-                                    selection.update(cx, |s, cx| {
-                                        s.shift_range(idx, Some(current), cx)
-                                    });
+                                    selection
+                                        .update(cx, |s, cx| s.shift_range(idx, Some(current), cx));
                                 } else {
                                     selection.update(cx, |s, cx| s.select(idx, cx));
                                 }
                             })
                         })
-                        .when(is_available && !is_selected && !item_state.is_being_dragged, |div| {
-                            div.hover(|div| div.bg(theme.queue_item_hover))
-                                .active(|div| div.bg(theme.queue_item_active))
-                        })
-                        .when(is_available && is_selected && !item_state.is_being_dragged, |div| {
-                            div.hover(|div| div.bg(theme.queue_item_selected))
-                                .active(|div| div.bg(theme.queue_item_active))
-                        })
+                        .when(
+                            is_available && !is_selected && !item_state.is_being_dragged,
+                            |div| {
+                                div.hover(|div| div.bg(theme.queue_item_hover))
+                                    .active(|div| div.bg(theme.queue_item_active))
+                            },
+                        )
+                        .when(
+                            is_available && is_selected && !item_state.is_being_dragged,
+                            |div| {
+                                div.hover(|div| div.bg(theme.queue_item_selected))
+                                    .active(|div| div.bg(theme.queue_item_active))
+                            },
+                        )
                         .when(is_available, |div| {
-                            div.on_drag(DragData::new(idx, QUEUE_LIST_ID), move |_, _, _, cx| {
+                            let drag_data = if is_selected {
+                                let all = selection_for_drag.read(cx).indices();
+                                let primary = all
+                                    .iter()
+                                    .position(|&i| i == idx)
+                                    .expect("is_selected implies idx is in selection");
+                                DragData::new(idx, QUEUE_LIST_ID).with_additional_indices({
+                                    let mut others: Vec<usize> = all;
+                                    others.remove(primary);
+                                    others
+                                })
+                            } else {
+                                DragData::new(idx, QUEUE_LIST_ID)
+                            };
+                            div.on_drag(drag_data, move |_, _, _, cx| {
                                 DragPreview::new(cx, track_name.clone())
                             })
                             .drag_over::<DragData>(
@@ -428,189 +446,190 @@ impl Render for QueueItem {
                                 ),
                         ),
                 )
-                .child(
-                    if is_multi_selected {
-                        let remove_indices = selected_indices.clone();
-                        let remove_count = selected_indices.len();
-                        let add_to_ids = selected_track_ids.clone();
-                        let entity_for_add = queue_item_entity.clone();
-                        let show_add_to_multi = self.show_add_to.clone();
+                .child(if is_multi_selected {
+                    let remove_indices = selected_indices.clone();
+                    let remove_count = selected_indices.len();
+                    let add_to_ids = selected_track_ids.clone();
+                    let entity_for_add = queue_item_entity.clone();
+                    let show_add_to_multi = self.show_add_to.clone();
 
-                        let liked_ids: Vec<i64> = selected_track_ids
-                            .iter()
-                            .copied()
-                            .filter(|id| {
-                                cx.playlist_has_track(LIKED_SONGS_PLAYLIST_ID, *id)
-                                    .ok()
-                                    .flatten()
-                                    .is_some()
-                            })
-                            .collect();
-                        let any_liked = !liked_ids.is_empty();
+                    let liked_ids: Vec<i64> = selected_track_ids
+                        .iter()
+                        .copied()
+                        .filter(|id| {
+                            cx.playlist_has_track(LIKED_SONGS_PLAYLIST_ID, *id)
+                                .ok()
+                                .flatten()
+                                .is_some()
+                        })
+                        .collect();
+                    let any_liked = !liked_ids.is_empty();
 
-                        menu()
-                            .when(!add_to_ids.is_empty(), |menu| {
-                                menu.item(menu_item(
-                                    "add_to_playlist",
-                                    Some(PLAYLIST_ADD),
-                                    tr!("ADD_TO_PLAYLIST"),
+                    menu()
+                        .when(!add_to_ids.is_empty(), |menu| {
+                            menu.item(menu_item(
+                                "add_to_playlist",
+                                Some(PLAYLIST_ADD),
+                                tr!("ADD_TO_PLAYLIST"),
+                                move |_, _, cx| {
+                                    entity_for_add.update(cx, |item, cx| match &item.add_to {
+                                        Some(add_to) => {
+                                            add_to.read(cx).set_track_ids(add_to_ids.clone());
+                                        }
+                                        None => {
+                                            item.add_to = Some(AddToPlaylist::new(
+                                                cx,
+                                                item.show_add_to.clone(),
+                                                add_to_ids.clone(),
+                                            ));
+                                        }
+                                    });
+                                    show_add_to_multi.write(cx, true);
+                                },
+                            ))
+                            .item(menu_separator())
+                        })
+                        .when(!selected_track_ids.is_empty(), |menu| {
+                            let track_ids_for_like = selected_track_ids.clone();
+                            let liked_ids = liked_ids.clone();
+                            menu.item(menu_item(
+                                "toggle_like",
+                                Some(if any_liked { STAR_FILLED } else { STAR }),
+                                if any_liked {
+                                    tr!("UNLIKE")
+                                } else {
+                                    tr!("LIKE")
+                                },
+                                move |_, _, cx| {
+                                    if any_liked {
+                                        for &track_id in &liked_ids {
+                                            let is_liked = cx
+                                                .playlist_has_track(
+                                                    LIKED_SONGS_PLAYLIST_ID,
+                                                    track_id,
+                                                )
+                                                .ok()
+                                                .flatten();
+                                            if is_liked.is_some() {
+                                                toggle_like_by_id(track_id, is_liked, cx);
+                                            }
+                                        }
+                                    } else {
+                                        for &track_id in &track_ids_for_like {
+                                            toggle_like_by_id(track_id, None, cx);
+                                        }
+                                    }
+                                },
+                            ))
+                            .item(menu_separator())
+                        })
+                        .item(menu_item(
+                            "remove_items",
+                            Some(CROSS),
+                            tr!(
+                                "REMOVE_N_FROM_QUEUE",
+                                "Remove {{count}} from queue",
+                                count = remove_count as isize
+                            ),
+                            move |_, _, cx| {
+                                cx.global::<PlaybackInterface>()
+                                    .remove_items(remove_indices.clone());
+                            },
+                        ))
+                } else {
+                    let entity_for_add = queue_item_entity.clone();
+                    menu()
+                        .when(self.add_to.is_some(), |menu| {
+                            menu.item(
+                                menu_item(
+                                    "go_to_album",
+                                    Some(DISC),
+                                    tr!("GO_TO_ALBUM", "Go to album"),
                                     move |_, _, cx| {
-                                        entity_for_add.update(cx, |item, cx| {
-                                            match &item.add_to {
-                                                Some(add_to) => {
-                                                    add_to.read(cx).set_track_ids(add_to_ids.clone());
-                                                }
-                                                None => {
-                                                    item.add_to = Some(AddToPlaylist::new(
-                                                        cx,
-                                                        item.show_add_to.clone(),
-                                                        add_to_ids.clone(),
-                                                    ));
-                                                }
+                                        if let Some(album_id) = album_id {
+                                            let switcher =
+                                                cx.global::<Models>().switcher_model.clone();
+                                            switcher.update(cx, |_, cx| {
+                                                cx.emit(ViewSwitchMessage::Release(album_id, None));
+                                            })
+                                        }
+                                    },
+                                )
+                                .disabled(!is_available),
+                            )
+                            .item(
+                                menu_item(
+                                    "go_to_artist",
+                                    Some(USERS),
+                                    tr!("GO_TO_ARTIST", "Go to artist"),
+                                    move |_, _, cx| {
+                                        if let Some(album_id) = album_id {
+                                            let Ok(artist_id) = cx.artist_id_for_album(album_id)
+                                            else {
+                                                return;
+                                            };
+
+                                            let switcher =
+                                                cx.global::<Models>().switcher_model.clone();
+                                            switcher.update(cx, |_, cx| {
+                                                cx.emit(ViewSwitchMessage::Artist(artist_id));
+                                            })
+                                        }
+                                    },
+                                )
+                                .disabled(!is_available),
+                            )
+                            .item(menu_separator())
+                            .item(menu_item(
+                                "add_to_playlist",
+                                Some(PLAYLIST_ADD),
+                                tr!("ADD_TO_PLAYLIST"),
+                                move |_, _, cx| {
+                                    if let Some(track_id) = single_track_id {
+                                        entity_for_add.update(cx, |item, cx| match &item.add_to {
+                                            Some(add_to) => {
+                                                add_to.read(cx).set_track_ids(vec![track_id]);
+                                            }
+                                            None => {
+                                                item.add_to = Some(AddToPlaylist::new(
+                                                    cx,
+                                                    item.show_add_to.clone(),
+                                                    vec![track_id],
+                                                ));
                                             }
                                         });
-                                        show_add_to_multi.write(cx, true);
-                                    },
-                                ))
-                                .item(menu_separator())
-                            })
-                            .when(!selected_track_ids.is_empty(), |menu| {
-                                let track_ids_for_like = selected_track_ids.clone();
-                                let liked_ids = liked_ids.clone();
-                                menu.item(menu_item(
-                                    "toggle_like",
-                                    Some(if any_liked { STAR_FILLED } else { STAR }),
-                                    if any_liked { tr!("UNLIKE") } else { tr!("LIKE") },
-                                    move |_, _, cx| {
-                                        if any_liked {
-                                            for &track_id in &liked_ids {
-                                                let is_liked = cx
-                                                    .playlist_has_track(LIKED_SONGS_PLAYLIST_ID, track_id)
-                                                    .ok()
-                                                    .flatten();
-                                                if is_liked.is_some() {
-                                                    toggle_like_by_id(track_id, is_liked, cx);
-                                                }
-                                            }
-                                        } else {
-                                            for &track_id in &track_ids_for_like {
-                                                toggle_like_by_id(track_id, None, cx);
-                                            }
-                                        }
-                                    },
-                                ))
-                                .item(menu_separator())
-                            })
-                            .item(menu_item(
-                                "remove_items",
-                                Some(CROSS),
-                                tr!(
-                                    "REMOVE_N_FROM_QUEUE",
-                                    "Remove {{count}} from queue",
-                                    count = remove_count as isize
-                                ),
-                                move |_, _, cx| {
-                                    cx.global::<PlaybackInterface>()
-                                        .remove_items(remove_indices.clone());
+                                    }
+                                    show_add_to.write(cx, true);
                                 },
                             ))
-                    } else {
-                        let entity_for_add = queue_item_entity.clone();
-                        menu()
-                            .when(self.add_to.is_some(), |menu| {
+                            .item(menu_separator())
+                            .when_some(self.track_id, |menu, track_id| {
+                                let entity = cx.entity().clone();
+                                let is_liked = self.is_liked.is_some();
                                 menu.item(
                                     menu_item(
-                                        "go_to_album",
-                                        Some(DISC),
-                                        tr!("GO_TO_ALBUM", "Go to album"),
+                                        "toggle_like",
+                                        Some(if is_liked { STAR_FILLED } else { STAR }),
+                                        if is_liked { tr!("UNLIKE") } else { tr!("LIKE") },
                                         move |_, _, cx| {
-                                            if let Some(album_id) = album_id {
-                                                let switcher =
-                                                    cx.global::<Models>().switcher_model.clone();
-                                                switcher.update(cx, |_, cx| {
-                                                    cx.emit(ViewSwitchMessage::Release(album_id, None));
-                                                })
-                                            }
+                                            toggle_like(track_id, entity.clone(), cx);
                                         },
                                     )
                                     .disabled(!is_available),
                                 )
-                                .item(
-                                    menu_item(
-                                        "go_to_artist",
-                                        Some(USERS),
-                                        tr!("GO_TO_ARTIST", "Go to artist"),
-                                        move |_, _, cx| {
-                                            if let Some(album_id) = album_id {
-                                                let Ok(artist_id) = cx.artist_id_for_album(album_id)
-                                                else {
-                                                    return;
-                                                };
-
-                                                let switcher =
-                                                    cx.global::<Models>().switcher_model.clone();
-                                                switcher.update(cx, |_, cx| {
-                                                    cx.emit(ViewSwitchMessage::Artist(artist_id));
-                                                })
-                                            }
-                                        },
-                                    )
-                                    .disabled(!is_available),
-                                )
-                                .item(menu_separator())
-                                .item(menu_item(
-                                    "add_to_playlist",
-                                    Some(PLAYLIST_ADD),
-                                    tr!("ADD_TO_PLAYLIST"),
-                                    move |_, _, cx| {
-                                        if let Some(track_id) = single_track_id {
-                                            entity_for_add.update(cx, |item, cx| {
-                                                match &item.add_to {
-                                                    Some(add_to) => {
-                                                        add_to.read(cx).set_track_ids(vec![track_id]);
-                                                    }
-                                                    None => {
-                                                        item.add_to = Some(AddToPlaylist::new(
-                                                            cx,
-                                                            item.show_add_to.clone(),
-                                                            vec![track_id],
-                                                        ));
-                                                    }
-                                                }
-                                            });
-                                        }
-                                        show_add_to.write(cx, true);
-                                    },
-                                ))
-                                .item(menu_separator())
-                                .when_some(self.track_id, |menu, track_id| {
-                                    let entity = cx.entity().clone();
-                                    let is_liked = self.is_liked.is_some();
-                                    menu.item(
-                                        menu_item(
-                                            "toggle_like",
-                                            Some(if is_liked { STAR_FILLED } else { STAR }),
-                                            if is_liked { tr!("UNLIKE") } else { tr!("LIKE") },
-                                            move |_, _, cx| {
-                                                toggle_like(track_id, entity.clone(), cx);
-                                            },
-                                        )
-                                        .disabled(!is_available),
-                                    )
-                                })
-                                .item(menu_separator())
                             })
-                            .item(menu_item(
-                                "remove_item",
-                                Some(CROSS),
-                                tr!("REMOVE_FROM_QUEUE", "Remove from queue"),
-                                move |_, _, cx| {
-                                    let playback = cx.global::<PlaybackInterface>();
-                                    playback.remove_item(idx);
-                                },
-                            ))
-                    },
-                )
+                            .item(menu_separator())
+                        })
+                        .item(menu_item(
+                            "remove_item",
+                            Some(CROSS),
+                            tr!("REMOVE_FROM_QUEUE", "Remove from queue"),
+                            move |_, _, cx| {
+                                let playback = cx.global::<PlaybackInterface>();
+                                playback.remove_item(idx);
+                            },
+                        ))
+                })
                 .into_any_element()
         } else {
             // TODO: Skeleton for this
@@ -1008,12 +1027,26 @@ impl Render for Queue {
                     ))
                     .on_drop(
                         cx.listener(move |this: &mut Queue, drag_data: &DragData, _, cx| {
-                            handle_drop(
+                            handle_drop_multi(
                                 this.drag_drop_manager.clone(),
                                 drag_data,
                                 cx,
-                                |from, to, cx| {
-                                    cx.global::<PlaybackInterface>().move_item(from, to);
+                                |drag_data, to, cx| {
+                                    if drag_data.additional_indices.is_empty() {
+                                        cx.global::<PlaybackInterface>()
+                                            .move_item(drag_data.source_index, to);
+                                    } else {
+                                        let corrected_to = to.saturating_sub(
+                                            drag_data
+                                                .additional_indices
+                                                .iter()
+                                                .filter(|&&idx| idx < to)
+                                                .count(),
+                                        );
+                                        let indices = drag_data.all_indices();
+                                        cx.global::<PlaybackInterface>()
+                                            .move_items(indices, corrected_to);
+                                    }
                                 },
                             );
                             cx.notify();

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -26,7 +26,7 @@ use crate::{
 use cntp_i18n::tr;
 use gpui::*;
 use prelude::FluentBuilder;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Duration;
 
 use super::{
@@ -47,12 +47,94 @@ const QUEUE_ITEM_HEIGHT: f32 = 60.0;
 /// Duration of the queue auto-follow animation.
 const QUEUE_FOLLOW_ANIMATION_DURATION: Duration = Duration::from_millis(180);
 
+/// Shared selection state for the queue.
+pub struct QueueSelection {
+    selected: FxHashSet<usize>,
+    anchor: Option<usize>,
+}
+
+impl QueueSelection {
+    pub fn new(cx: &mut App) -> Entity<Self> {
+        cx.new(|_| Self {
+            selected: FxHashSet::default(),
+            anchor: None,
+        })
+    }
+
+    pub fn contains(&self, index: usize) -> bool {
+        self.selected.contains(&index)
+    }
+
+    pub fn is_multi(&self) -> bool {
+        self.selected.len() > 1
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.selected.is_empty()
+    }
+
+    pub fn indices(&self) -> Vec<usize> {
+        let mut v: Vec<usize> = self.selected.iter().copied().collect();
+        v.sort_unstable();
+        v
+    }
+
+    pub fn clear(&mut self, cx: &mut Context<Self>) {
+        self.selected.clear();
+        self.anchor = None;
+        cx.notify();
+    }
+
+    /// Plain click: deselect all, select only this item.
+    pub fn select(&mut self, index: usize, cx: &mut Context<Self>) {
+        self.selected.clear();
+        self.selected.insert(index);
+        self.anchor = Some(index);
+        cx.notify();
+    }
+
+    /// Ctrl/Cmd+click: toggle this item in the selection.
+    pub fn ctrl_toggle(&mut self, index: usize, cx: &mut Context<Self>) {
+        if self.selected.contains(&index) {
+            self.selected.remove(&index);
+            if self.anchor == Some(index) {
+                self.anchor = self.selected.iter().copied().next();
+            }
+        } else {
+            self.selected.insert(index);
+            self.anchor = Some(index);
+        }
+        cx.notify();
+    }
+
+    /// Shift+click: select range from anchor to this item.
+    /// Replaces any previous range selection. If no anchor exists,
+    /// uses `current_position` (the currently-playing track) as the anchor.
+    pub fn shift_range(
+        &mut self,
+        index: usize,
+        current_position: Option<usize>,
+        cx: &mut Context<Self>,
+    ) {
+        let anchor = self.anchor.or(current_position).unwrap_or(index);
+        self.anchor = Some(anchor);
+        self.selected.clear();
+        let start = anchor.min(index);
+        let end = anchor.max(index);
+        for i in start..=end {
+            self.selected.insert(i);
+        }
+        cx.notify();
+    }
+}
+
 pub struct QueueItem {
     item: Option<QueueItemData>,
     current: usize,
     idx: usize,
     drag_drop_manager: Entity<DragDropListManager>,
     scroll_handle: UniformListScrollHandle,
+    selection: Entity<QueueSelection>,
     add_to: Option<Entity<AddToPlaylist>>,
     show_add_to: Entity<bool>,
     track_id: Option<i64>,
@@ -75,6 +157,7 @@ impl QueueItem {
         idx: usize,
         drag_drop_manager: Entity<DragDropListManager>,
         scroll_handle: UniformListScrollHandle,
+        selection: Entity<QueueSelection>,
     ) -> Entity<Self> {
         cx.new(move |cx| {
             cx.on_release(|m: &mut QueueItem, cx| {
@@ -106,6 +189,11 @@ impl QueueItem {
             })
             .detach();
 
+            cx.observe(&selection, |_, _, cx| {
+                cx.notify();
+            })
+            .detach();
+
             let show_add_to = cx.new(|_| false);
             let add_to =
                 track_id.map(|track_id| AddToPlaylist::new(cx, show_add_to.clone(), track_id));
@@ -123,6 +211,7 @@ impl QueueItem {
                 current: queue.read(cx).position,
                 drag_drop_manager,
                 scroll_handle,
+                selection,
                 add_to,
                 show_add_to,
                 track_id,
@@ -147,6 +236,7 @@ impl Render for QueueItem {
             .item
             .as_ref()
             .is_some_and(|queue_item| is_track_path_available(queue_item.get_path()));
+        let is_selected = self.selection.read(cx).contains(self.idx);
 
         if let Some(item) = ui_data.as_ref() {
             let scrollbar_always_visible = {
@@ -163,6 +253,8 @@ impl Render for QueueItem {
                     .map(|i| ManagedImageKey::TrackFile(i.get_path().to_path_buf()))
             });
             let idx = self.idx;
+            let current = self.current;
+            let selection = self.selection.clone();
 
             let item_state =
                 DragDropItemState::for_index(self.drag_drop_manager.read(cx), self.idx);
@@ -194,16 +286,37 @@ impl Render for QueueItem {
                         .border_b(px(1.0))
                         .border_color(theme.border_color)
                         .when(item_state.is_being_dragged, |div| div.opacity(0.5))
-                        .when(is_current && !item_state.is_being_dragged, |div| {
+                        .when(is_selected && !item_state.is_being_dragged, |div| {
+                            div.bg(theme.queue_item_selected)
+                        })
+                        .when(!is_selected && is_current && !item_state.is_being_dragged, |div| {
                             div.bg(theme.queue_item_current)
                         })
                         .when(is_available, |div| {
-                            div.on_click(move |_, _, cx| {
-                                cx.global::<PlaybackInterface>().jump(idx);
+                            div.on_click(move |event: &ClickEvent, _, cx| {
+                                cx.stop_propagation();
+                                let modifiers = event.modifiers();
+                                let ctrl = modifiers.control || modifiers.platform;
+
+                                if event.click_count() == 2 {
+                                    cx.global::<PlaybackInterface>().jump(idx);
+                                } else if ctrl {
+                                    selection.update(cx, |s, cx| s.ctrl_toggle(idx, cx));
+                                } else if modifiers.shift {
+                                    selection.update(cx, |s, cx| {
+                                        s.shift_range(idx, Some(current), cx)
+                                    });
+                                } else {
+                                    selection.update(cx, |s, cx| s.select(idx, cx));
+                                }
                             })
                         })
-                        .when(is_available && !item_state.is_being_dragged, |div| {
+                        .when(is_available && !is_selected && !item_state.is_being_dragged, |div| {
                             div.hover(|div| div.bg(theme.queue_item_hover))
+                                .active(|div| div.bg(theme.queue_item_active))
+                        })
+                        .when(is_available && is_selected && !item_state.is_being_dragged, |div| {
+                            div.hover(|div| div.bg(theme.queue_item_selected))
                                 .active(|div| div.bg(theme.queue_item_active))
                         })
                         .when(is_available, |div| {
@@ -387,6 +500,7 @@ pub struct Queue {
     show_queue: Entity<bool>,
     scroll_handle: UniformListScrollHandle,
     drag_drop_manager: Entity<DragDropListManager>,
+    selection: Entity<QueueSelection>,
     last_queue_position: usize,
     queue_hovered: bool,
     follow_current_pending: bool,
@@ -405,6 +519,7 @@ impl Queue {
 
             let config = DragDropListConfig::new(QUEUE_LIST_ID, px(QUEUE_ITEM_HEIGHT));
             let drag_drop_manager = DragDropListManager::new(cx, config);
+            let selection = QueueSelection::new(cx);
 
             cx.observe(&items, move |this: &mut Queue, _, cx| {
                 let new_position = cx.global::<Models>().queue.read(cx).position;
@@ -426,6 +541,8 @@ impl Queue {
                     .collect();
                 retain_views(&this.views_model, &valid_keys, cx);
 
+                this.selection.update(cx, |s, cx| s.clear(cx));
+
                 cx.notify();
             })
             .detach();
@@ -435,6 +552,7 @@ impl Queue {
                 show_queue,
                 scroll_handle: UniformListScrollHandle::new(),
                 drag_drop_manager,
+                selection,
                 last_queue_position: initial_queue_position,
                 queue_hovered: false,
                 follow_current_pending: initial_has_current_track,
@@ -463,6 +581,7 @@ impl Render for Queue {
         let scroll_handle = self.scroll_handle.clone();
         let item_scroll_handle = scroll_handle.clone();
         let drag_drop_manager = self.drag_drop_manager.clone();
+        let selection = self.selection.clone();
         let reduced_motion = cx
             .global::<SettingsGlobal>()
             .model
@@ -535,6 +654,9 @@ impl Render for Queue {
                     .w_full()
                     .h_full()
                     .relative()
+                    .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
+                        this.selection.update(cx, |s, cx| s.clear(cx));
+                    }))
                     .on_hover(cx.listener(|this, is_hovering: &bool, _, cx| {
                         if this.queue_hovered == *is_hovering {
                             return;
@@ -859,6 +981,7 @@ impl Render for Queue {
 
                                         let drag_drop_manager = drag_drop_manager.clone();
                                         let scroll_handle = item_scroll_handle.clone();
+                                        let item_selection = selection.clone();
 
                                         let view = create_or_retrieve_view_keyed(
                                             &views_model,
@@ -870,6 +993,7 @@ impl Render for Queue {
                                                     idx,
                                                     drag_drop_manager,
                                                     scroll_handle,
+                                                    item_selection,
                                                 )
                                             },
                                             cx,

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -54,6 +54,7 @@ pub struct Theme {
     pub queue_item_hover: Rgba,
     pub queue_item_active: Rgba,
     pub queue_item_current: Rgba,
+    pub queue_item_selected: Rgba,
 
     pub button_primary: Rgba,
     pub button_primary_border: Rgba,
@@ -174,6 +175,7 @@ impl Default for Theme {
             queue_item_hover: rgb(0x151621),
             queue_item_active: rgb(0x101118),
             queue_item_current: rgb(0x1B1C28),
+            queue_item_selected: rgb(0x1A2040),
 
             close_button: rgba(0x00000000),
             close_button_hover: rgb(0x7E2C2C),

--- a/translations/en.json
+++ b/translations/en.json
@@ -147,7 +147,10 @@
   "REMOVE_FROM_PLAYLIST": "Remove from playlist",
   "REMOVE_FROM_QUEUE": "Remove from queue",
   "REMOVE_FROM_SELECTED_PLAYLIST": "Remove from {{name}}",
-  "REMOVE_N_FROM_QUEUE": "Remove {{count}} from queue",
+  "REMOVE_N_FROM_QUEUE": {
+    "one": "Remove {{count}} track from queue",
+    "other": "Remove {{count}} tracks from queue"
+  },
   "RENAME": "Rename",
   "RENAME_PLAYLIST": "Rename playlist",
   "REPEAT": "Repeat",

--- a/translations/en.json
+++ b/translations/en.json
@@ -147,6 +147,7 @@
   "REMOVE_FROM_PLAYLIST": "Remove from playlist",
   "REMOVE_FROM_QUEUE": "Remove from queue",
   "REMOVE_FROM_SELECTED_PLAYLIST": "Remove from {{name}}",
+  "REMOVE_N_FROM_QUEUE": "Remove {{count}} from queue",
   "RENAME": "Rename",
   "RENAME_PLAYLIST": "Rename playlist",
   "REPEAT": "Repeat",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -265,7 +265,7 @@
   },
   "CLEAR_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:785",
+    "definedIn": "src/ui/queue.rs:786",
     "plural": false,
     "description": null
   },
@@ -277,7 +277,7 @@
   },
   "CLOSE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:796",
+    "definedIn": "src/ui/queue.rs:797",
     "plural": false,
     "description": null
   },
@@ -439,13 +439,13 @@
   },
   "GO_TO_ALBUM": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:547",
+    "definedIn": "src/ui/queue.rs:548",
     "plural": false,
     "description": null
   },
   "GO_TO_ARTIST": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:564",
+    "definedIn": "src/ui/queue.rs:565",
     "plural": false,
     "description": null
   },
@@ -781,7 +781,7 @@
   },
   "QUEUE_TITLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:777",
+    "definedIn": "src/ui/queue.rs:778",
     "plural": false,
     "description": null
   },
@@ -823,7 +823,7 @@
   },
   "REMOVE_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:626",
+    "definedIn": "src/ui/queue.rs:627",
     "plural": false,
     "description": null
   },
@@ -836,7 +836,7 @@
   "REMOVE_N_FROM_QUEUE": {
     "context": "queue.rs",
     "definedIn": "src/ui/queue.rs:530",
-    "plural": false,
+    "plural": true,
     "description": null
   },
   "RENAME": {

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -265,7 +265,7 @@
   },
   "CLEAR_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:517",
+    "definedIn": "src/ui/queue.rs:636",
     "plural": false,
     "description": null
   },
@@ -277,7 +277,7 @@
   },
   "CLOSE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:528",
+    "definedIn": "src/ui/queue.rs:647",
     "plural": false,
     "description": null
   },
@@ -439,13 +439,13 @@
   },
   "GO_TO_ALBUM": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:299",
+    "definedIn": "src/ui/queue.rs:412",
     "plural": false,
     "description": null
   },
   "GO_TO_ARTIST": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:316",
+    "definedIn": "src/ui/queue.rs:429",
     "plural": false,
     "description": null
   },
@@ -781,7 +781,7 @@
   },
   "QUEUE_TITLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:509",
+    "definedIn": "src/ui/queue.rs:628",
     "plural": false,
     "description": null
   },
@@ -823,7 +823,7 @@
   },
   "REMOVE_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:364",
+    "definedIn": "src/ui/queue.rs:477",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -217,7 +217,7 @@
   },
   "ADD_TO_SELECTED_PLAYLIST": {
     "context": "add_to_playlist.rs",
-    "definedIn": "src/ui/library/add_to_playlist.rs:38",
+    "definedIn": "src/ui/library/add_to_playlist.rs:85",
     "plural": false,
     "description": null
   },
@@ -265,7 +265,7 @@
   },
   "CLEAR_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:636",
+    "definedIn": "src/ui/queue.rs:766",
     "plural": false,
     "description": null
   },
@@ -277,7 +277,7 @@
   },
   "CLOSE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:647",
+    "definedIn": "src/ui/queue.rs:777",
     "plural": false,
     "description": null
   },
@@ -439,13 +439,13 @@
   },
   "GO_TO_ALBUM": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:412",
+    "definedIn": "src/ui/queue.rs:525",
     "plural": false,
     "description": null
   },
   "GO_TO_ARTIST": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:429",
+    "definedIn": "src/ui/queue.rs:542",
     "plural": false,
     "description": null
   },
@@ -781,7 +781,7 @@
   },
   "QUEUE_TITLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:628",
+    "definedIn": "src/ui/queue.rs:758",
     "plural": false,
     "description": null
   },
@@ -823,13 +823,19 @@
   },
   "REMOVE_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:477",
+    "definedIn": "src/ui/queue.rs:606",
     "plural": false,
     "description": null
   },
   "REMOVE_FROM_SELECTED_PLAYLIST": {
     "context": "add_to_playlist.rs",
-    "definedIn": "src/ui/library/add_to_playlist.rs:45",
+    "definedIn": "src/ui/library/add_to_playlist.rs:92",
+    "plural": false,
+    "description": null
+  },
+  "REMOVE_N_FROM_QUEUE": {
+    "context": "queue.rs",
+    "definedIn": "src/ui/queue.rs:508",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -217,7 +217,7 @@
   },
   "ADD_TO_SELECTED_PLAYLIST": {
     "context": "add_to_playlist.rs",
-    "definedIn": "src/ui/library/add_to_playlist.rs:85",
+    "definedIn": "src/ui/library/add_to_playlist.rs:81",
     "plural": false,
     "description": null
   },
@@ -265,7 +265,7 @@
   },
   "CLEAR_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:766",
+    "definedIn": "src/ui/queue.rs:785",
     "plural": false,
     "description": null
   },
@@ -277,7 +277,7 @@
   },
   "CLOSE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:777",
+    "definedIn": "src/ui/queue.rs:796",
     "plural": false,
     "description": null
   },
@@ -439,13 +439,13 @@
   },
   "GO_TO_ALBUM": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:525",
+    "definedIn": "src/ui/queue.rs:547",
     "plural": false,
     "description": null
   },
   "GO_TO_ARTIST": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:542",
+    "definedIn": "src/ui/queue.rs:564",
     "plural": false,
     "description": null
   },
@@ -781,7 +781,7 @@
   },
   "QUEUE_TITLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:758",
+    "definedIn": "src/ui/queue.rs:777",
     "plural": false,
     "description": null
   },
@@ -823,19 +823,19 @@
   },
   "REMOVE_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:606",
+    "definedIn": "src/ui/queue.rs:626",
     "plural": false,
     "description": null
   },
   "REMOVE_FROM_SELECTED_PLAYLIST": {
     "context": "add_to_playlist.rs",
-    "definedIn": "src/ui/library/add_to_playlist.rs:92",
+    "definedIn": "src/ui/library/add_to_playlist.rs:88",
     "plural": false,
     "description": null
   },
   "REMOVE_N_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:508",
+    "definedIn": "src/ui/queue.rs:530",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
Closes #110 

## Changes
queue multi-selection with single-click-to-select / double-click-to-play, Ctrl/Cmd and Shift click for range/additive selection, adds batch context menu actions (remove, add to playlist, like), and multi-item drag-and-drop.

## Testing
tested basically every case I could think of manually and added a bunch of tests for new logic.

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [x] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
