### PR TITLE
feat: add stop after current

### DIFF
--- a/src/playback/events.rs
+++ b/src/playback/events.rs
@@ -67,6 +67,8 @@ pub enum PlaybackCommand {
     ReplaceQueue(Vec<QueueItemData>),
     /// Requests that the playback thread stop playback.
     Stop,
+    /// Requests that playback stop when the current track finishes.
+    StopAfterCurrent,
     /// Requests that the playback thread shuffle (or stop shuffling) the next tracks in the
     /// queue. Note that this currently results in duplication of the *entire* queue.
     ToggleShuffle,
@@ -125,4 +127,6 @@ pub enum PlaybackEvent {
     RepeatChanged(RepeatState),
     /// Indicates that the volume has changed. The f64 is the new volume, from 0.0 to 1.0.
     VolumeChanged(f64),
+    /// Indicates that stop-after-current has been set or cleared.
+    StopAfterCurrentChanged(bool),
 }

--- a/src/playback/events.rs
+++ b/src/playback/events.rs
@@ -67,7 +67,7 @@ pub enum PlaybackCommand {
     ReplaceQueue(Vec<QueueItemData>),
     /// Requests that the playback thread stop playback.
     Stop,
-    /// Requests that playback stop when the current track finishes.
+    /// Toggles whether playback should stop when the current track finishes.
     StopAfterCurrent,
     /// Requests that the playback thread shuffle (or stop shuffling) the next tracks in the
     /// queue. Note that this currently results in duplication of the *entire* queue.

--- a/src/playback/interface.rs
+++ b/src/playback/interface.rs
@@ -127,7 +127,7 @@ impl PlaybackInterface {
         self.cmd_tx.send(PlaybackCommand::Stop).unwrap();
     }
 
-    pub fn stop_after_current(&self) {
+    pub fn toggle_stop_after_current(&self) {
         self.cmd_tx.send(PlaybackCommand::StopAfterCurrent).unwrap();
     }
 

--- a/src/playback/interface.rs
+++ b/src/playback/interface.rs
@@ -127,6 +127,10 @@ impl PlaybackInterface {
         self.cmd_tx.send(PlaybackCommand::Stop).unwrap();
     }
 
+    pub fn stop_after_current(&self) {
+        self.cmd_tx.send(PlaybackCommand::StopAfterCurrent).unwrap();
+    }
+
     pub fn toggle_shuffle(&self) {
         self.cmd_tx.send(PlaybackCommand::ToggleShuffle).unwrap();
     }
@@ -315,6 +319,12 @@ impl PlaybackInterface {
                         }
                         PlaybackEvent::RepeatChanged(v) => {
                             playback_info.repeating.update(cx, |m, cx| {
+                                *m = v;
+                                cx.notify();
+                            })
+                        }
+                        PlaybackEvent::StopAfterCurrentChanged(v) => {
+                            playback_info.stop_after_current.update(cx, |m, cx| {
                                 *m = v;
                                 cx.notify();
                             })

--- a/src/playback/thread.rs
+++ b/src/playback/thread.rs
@@ -207,7 +207,7 @@ impl PlaybackThread {
                 PlaybackCommand::ReplaceQueueWithIndex(v, idx) => {
                     self.replace_queue_with_index(v, idx)
                 }
-                PlaybackCommand::StopAfterCurrent => self.stop_after_current(),
+                PlaybackCommand::StopAfterCurrent => self.toggle_stop_after_current(),
             }
         }
     }
@@ -893,9 +893,9 @@ impl PlaybackThread {
         self.send_event(PlaybackEvent::StateChanged(PlaybackState::Stopped));
     }
 
-    fn stop_after_current(&mut self) {
+    fn toggle_stop_after_current(&mut self) {
         if self.state() != PlaybackState::Stopped {
-            self.set_stop_after_current(true);
+            self.set_stop_after_current(!self.stop_after_current);
         }
     }
 

--- a/src/playback/thread.rs
+++ b/src/playback/thread.rs
@@ -84,6 +84,7 @@ pub struct PlaybackThread {
     last_track_gain: Option<f64>,
     /// Cached album gain from last metadata update.
     last_album_gain: Option<f64>,
+    stop_after_current: bool,
 }
 
 impl PlaybackThread {
@@ -117,6 +118,7 @@ impl PlaybackThread {
                     rg_auto_hint: ReplayGainAutoHint::PreferTrack,
                     last_track_gain: None,
                     last_album_gain: None,
+                    stop_after_current: false,
                 };
 
                 thread.run();
@@ -171,6 +173,7 @@ impl PlaybackThread {
                 PlaybackCommand::Pause => self.pause(),
                 PlaybackCommand::TogglePlayPause => self.toggle_play_pause(),
                 PlaybackCommand::Open(path) => {
+                    self.set_stop_after_current(false);
                     if let Err(err) = self.open(&path) {
                         error!(path = %path.display(), ?err, "Failed to open media: {err}");
                     }
@@ -204,6 +207,7 @@ impl PlaybackThread {
                 PlaybackCommand::ReplaceQueueWithIndex(v, idx) => {
                     self.replace_queue_with_index(v, idx)
                 }
+                PlaybackCommand::StopAfterCurrent => self.stop_after_current(),
             }
         }
     }
@@ -331,6 +335,10 @@ impl PlaybackThread {
 
     /// Skip to the next track in the queue.
     fn next(&mut self, user_initiated: bool) {
+        if user_initiated {
+            self.set_stop_after_current(false);
+        }
+
         match self.queue.next(user_initiated) {
             QueueNavigationResult::Changed {
                 index,
@@ -364,6 +372,8 @@ impl PlaybackThread {
 
     /// Skip to the previous track in the queue.
     fn previous(&mut self) {
+        self.set_stop_after_current(false);
+
         // If we're past 5 seconds, seek to start instead of going to previous track
         if self.state() == PlaybackState::Playing
             && self.playback_settings.prev_track_jump_first
@@ -575,6 +585,7 @@ impl PlaybackThread {
                 }
             }
             DequeueResult::RemovedCurrent { new_path } => {
+                self.set_stop_after_current(false);
                 self.refresh_rg_auto_hint();
                 self.send_event(PlaybackEvent::QueueUpdated);
 
@@ -607,6 +618,7 @@ impl PlaybackThread {
                 }
             }
             DequeueManyResult::RemovedCurrent { new_path } => {
+                self.set_stop_after_current(false);
                 self.refresh_rg_auto_hint();
                 self.send_event(PlaybackEvent::QueueUpdated);
 
@@ -780,6 +792,7 @@ impl PlaybackThread {
     fn jump(&mut self, index: usize) {
         match self.queue.jump(index) {
             JumpResult::Jumped { path } => {
+                self.set_stop_after_current(false);
                 if let Err(err) = self.open(&path) {
                     error!(path = %path.display(), ?err, "Unable to open file: {err}");
                 }
@@ -796,6 +809,7 @@ impl PlaybackThread {
     fn jump_unshuffled(&mut self, index: usize) {
         match self.queue.jump_unshuffled(index) {
             JumpResult::Jumped { path } => {
+                self.set_stop_after_current(false);
                 if let Err(err) = self.open(&path) {
                     error!(path = %path.display(), ?err, "Unable to open file: {err}");
                 }
@@ -813,6 +827,7 @@ impl PlaybackThread {
     /// Replace the current queue with the given paths.
     fn replace_queue(&mut self, paths: Vec<QueueItemData>) {
         debug!("Replacing queue with: '{}'", paths.iter().format(":"));
+        self.set_stop_after_current(false);
 
         match self.queue.replace_queue(paths) {
             ReplaceResult::Replaced { first_item } => {
@@ -833,6 +848,8 @@ impl PlaybackThread {
     }
 
     fn replace_queue_with_index(&mut self, paths: Vec<QueueItemData>, idx: usize) {
+        self.set_stop_after_current(false);
+
         match self.queue.replace_queue(paths) {
             ReplaceResult::Replaced { .. } => {
                 self.refresh_rg_auto_hint();
@@ -849,6 +866,8 @@ impl PlaybackThread {
 
     /// Clear the current queue.
     fn clear_queue(&mut self) {
+        self.set_stop_after_current(false);
+
         let keep_current = self.playback_settings.keep_current_on_queue_clear
             && self.state() != PlaybackState::Stopped;
         self.queue.clear(keep_current);
@@ -866,11 +885,27 @@ impl PlaybackThread {
 
     /// Stop the current playback.
     fn stop(&mut self) {
+        self.set_stop_after_current(false);
         self.engine.stop();
         self.last_track_gain = None;
         self.last_album_gain = None;
 
         self.send_event(PlaybackEvent::StateChanged(PlaybackState::Stopped));
+    }
+
+    fn stop_after_current(&mut self) {
+        if self.state() != PlaybackState::Stopped {
+            self.set_stop_after_current(true);
+        }
+    }
+
+    fn set_stop_after_current(&mut self, stop_after_current: bool) {
+        if self.stop_after_current == stop_after_current {
+            return;
+        }
+
+        self.stop_after_current = stop_after_current;
+        self.send_event(PlaybackEvent::StopAfterCurrentChanged(stop_after_current));
     }
 
     /// Toggle shuffle mode. This will result in the queue being duplicated and shuffled.
@@ -941,12 +976,22 @@ impl PlaybackThread {
                 self.update_ts(false);
             }
             EngineCycleResult::Eof => {
-                info!("EOF, moving to next song");
-                self.next(false);
+                if self.stop_after_current {
+                    info!("EOF, stopping after current track");
+                    self.stop();
+                } else {
+                    info!("EOF, moving to next song");
+                    self.next(false);
+                }
             }
             EngineCycleResult::FatalError(msg) => {
-                error!("Fatal error in audio engine: {}, moving to next song", msg);
-                self.next(false);
+                if self.stop_after_current {
+                    error!("Fatal error in audio engine: {}, stopping playback", msg);
+                    self.stop();
+                } else {
+                    error!("Fatal error in audio engine: {}, moving to next song", msg);
+                    self.next(false);
+                }
             }
             EngineCycleResult::NothingToDo => {
                 // Nothing to process

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -20,6 +20,7 @@ use crate::ui::{
     },
     global_actions::{
         About, ForceScan, Next, PlayPause, Previous, Quit, Search, Settings, ShuffleAll,
+        StopAfterCurrent,
     },
     troubleshooting::{CopyTroubleshootingInfo, OpenLog},
 };
@@ -240,6 +241,12 @@ fn builtin_commands() -> Vec<CommandSpec> {
             Some(CommandCategory::Playback),
             tr!("ACTION_SHUFFLE_ALL", "Shuffle All Tracks"),
             ShuffleAll,
+        ),
+        CommandSpec::new(
+            ("player::stop_after_current", 0),
+            Some(CommandCategory::Playback),
+            tr!("ACTION_STOP_AFTER_CURRENT", "Stop After Current"),
+            StopAfterCurrent,
         ),
         CommandSpec::new(
             ("scan::forcescan", 0),

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -632,7 +632,7 @@ impl Render for PlaybackSection {
                                         .right(px(3.0))
                                         .size(px(6.0))
                                         .rounded_full()
-                                        .bg(theme.playback_button_toggled)
+                                        .bg(theme.stop_after_current_indicator)
                                         .tooltip(build_tooltip(tr!(
                                             "STOP_AFTER_CURRENT_TOOLTIP",
                                             "Will stop after current track"

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -480,6 +480,8 @@ impl PlaybackSection {
             let info = cx.global::<PlaybackInfo>().clone();
             let state = info.playback_state.clone();
             let shuffling = info.shuffling.clone();
+            let repeating = info.repeating.clone();
+            let stop_after_current = info.stop_after_current.clone();
 
             cx.observe(&state, |_, _, cx| {
                 cx.notify();
@@ -487,6 +489,16 @@ impl PlaybackSection {
             .detach();
 
             cx.observe(&shuffling, |_, _, cx| {
+                cx.notify();
+            })
+            .detach();
+
+            cx.observe(&repeating, |_, _, cx| {
+                cx.notify();
+            })
+            .detach();
+
+            cx.observe(&stop_after_current, |_, _, cx| {
                 cx.notify();
             })
             .detach();
@@ -501,6 +513,7 @@ impl Render for PlaybackSection {
         let state = self.info.playback_state.read(cx);
         let shuffling = self.info.shuffling.read(cx);
         let repeating = *self.info.repeating.read(cx);
+        let stop_after_current = *self.info.stop_after_current.read(cx);
         let theme = cx.global::<Theme>();
         let always_repeat = cx
             .global::<SettingsGlobal>()
@@ -588,6 +601,7 @@ impl Render for PlaybackSection {
                             .border_l(px(1.0))
                             .border_r(px(1.0))
                             .border_color(theme.playback_button_border)
+                            .relative()
                             .flex()
                             .items_center()
                             .justify_center()
@@ -608,6 +622,22 @@ impl Render for PlaybackSection {
                             .when(*state != PlaybackState::Playing, |div| {
                                 div.child(icon(PLAY).size(px(16.0)))
                                     .tooltip(build_tooltip(tr!("PLAY")))
+                            })
+                            .when(stop_after_current, |this| {
+                                this.child(
+                                    div()
+                                        .id("stop-after-current-indicator")
+                                        .absolute()
+                                        .top(px(3.0))
+                                        .right(px(3.0))
+                                        .size(px(6.0))
+                                        .rounded_full()
+                                        .bg(theme.playback_button_toggled)
+                                        .tooltip(build_tooltip(tr!(
+                                            "STOP_AFTER_CURRENT_TOOLTIP",
+                                            "Will stop after current track"
+                                        ))),
+                                )
                             }),
                     )
                     .child(

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -13,7 +13,7 @@ use crate::{
                 REPEAT_ONCE, SHUFFLE, STAR, STAR_FILLED, VOLUME, VOLUME_OFF, icon,
             },
             managed_image::{ManagedImageKey, managed_image},
-            menu::{menu, menu_item},
+            menu::{menu, menu_check_item, menu_item},
             tooltip::build_tooltip,
             volume_tooltip::build_volume_tooltip,
         },
@@ -39,7 +39,7 @@ use super::{
         slider::slider,
     },
     constants::APP_ROUNDING,
-    global_actions::{Next, PlayPause, Previous},
+    global_actions::{Next, PlayPause, Previous, StopAfterCurrent},
     models::{Models, PlaybackInfo},
     theme::Theme,
 };
@@ -594,51 +594,64 @@ impl Render for PlaybackSection {
                             .tooltip(build_tooltip(tr!("PREVIOUS_TRACK", "Previous Track"))),
                     )
                     .child(
-                        div()
-                            .w(px(32.0))
-                            .h(px(28.0))
-                            .bg(theme.playback_button)
-                            .border_l(px(1.0))
-                            .border_r(px(1.0))
-                            .border_color(theme.playback_button_border)
-                            .relative()
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .hover(|style| style.bg(theme.playback_button_hover).cursor_pointer())
-                            .id("header-play-button")
-                            .active(|style| style.bg(theme.playback_button_active))
-                            .on_mouse_down(MouseButton::Left, |_, window, cx| {
-                                cx.stop_propagation();
-                                window.prevent_default();
-                            })
-                            .on_click(|_, window, cx| {
-                                window.dispatch_action(Box::new(PlayPause), cx);
-                            })
-                            .when(*state == PlaybackState::Playing, |div| {
-                                div.child(icon(PAUSE).size(px(16.0)))
-                                    .tooltip(build_tooltip(tr!("PAUSE")))
-                            })
-                            .when(*state != PlaybackState::Playing, |div| {
-                                div.child(icon(PLAY).size(px(16.0)))
-                                    .tooltip(build_tooltip(tr!("PLAY")))
-                            })
-                            .when(stop_after_current, |this| {
-                                this.child(
-                                    div()
-                                        .id("stop-after-current-indicator")
-                                        .absolute()
-                                        .top(px(3.0))
-                                        .right(px(3.0))
-                                        .size(px(6.0))
-                                        .rounded_full()
-                                        .bg(theme.stop_after_current_indicator)
-                                        .tooltip(build_tooltip(tr!(
-                                            "STOP_AFTER_CURRENT_TOOLTIP",
-                                            "Will stop after current track"
-                                        ))),
-                                )
-                            }),
+                        context("header-play-button-context")
+                            .with(
+                                div()
+                                    .w(px(32.0))
+                                    .h(px(28.0))
+                                    .bg(theme.playback_button)
+                                    .border_l(px(1.0))
+                                    .border_r(px(1.0))
+                                    .border_color(theme.playback_button_border)
+                                    .relative()
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .hover(|style| {
+                                        style.bg(theme.playback_button_hover).cursor_pointer()
+                                    })
+                                    .id("header-play-button")
+                                    .active(|style| style.bg(theme.playback_button_active))
+                                    .on_mouse_down(MouseButton::Left, |_, window, cx| {
+                                        cx.stop_propagation();
+                                        window.prevent_default();
+                                    })
+                                    .on_click(|_, window, cx| {
+                                        window.dispatch_action(Box::new(PlayPause), cx);
+                                    })
+                                    .when(*state == PlaybackState::Playing, |div| {
+                                        div.child(icon(PAUSE).size(px(16.0)))
+                                            .tooltip(build_tooltip(tr!("PAUSE")))
+                                    })
+                                    .when(*state != PlaybackState::Playing, |div| {
+                                        div.child(icon(PLAY).size(px(16.0)))
+                                            .tooltip(build_tooltip(tr!("PLAY")))
+                                    })
+                                    .when(stop_after_current, |this| {
+                                        this.child(
+                                            div()
+                                                .id("stop-after-current-indicator")
+                                                .absolute()
+                                                .top(px(3.0))
+                                                .right(px(3.0))
+                                                .size(px(6.0))
+                                                .rounded_full()
+                                                .bg(theme.stop_after_current_indicator)
+                                                .tooltip(build_tooltip(tr!(
+                                                    "STOP_AFTER_CURRENT_TOOLTIP",
+                                                    "Will stop after current track"
+                                                ))),
+                                        )
+                                    }),
+                            )
+                            .child(menu().item(menu_check_item(
+                                "stop-after-current-menu-item",
+                                stop_after_current,
+                                tr!("ACTION_STOP_AFTER_CURRENT"),
+                                |_, window, cx| {
+                                    window.dispatch_action(Box::new(StopAfterCurrent), cx);
+                                },
+                            ))),
                     )
                     .child(
                         div()

--- a/src/ui/global_actions.rs
+++ b/src/ui/global_actions.rs
@@ -363,5 +363,5 @@ fn undo(_: &Undo, cx: &mut App) {
 
 fn stop_after_current(_: &StopAfterCurrent, cx: &mut App) {
     let interface = cx.global::<PlaybackInterface>();
-    interface.stop_after_current();
+    interface.toggle_stop_after_current();
 }

--- a/src/ui/global_actions.rs
+++ b/src/ui/global_actions.rs
@@ -21,7 +21,10 @@ use super::models::{Models, PlaybackInfo};
 actions!(hummingbird, [Quit, About, CloseWindow, Search, Settings]);
 #[cfg(feature = "update")]
 actions!(hummingbird, [CheckForUpdates]);
-actions!(player, [PlayPause, Next, Previous, ShuffleAll]);
+actions!(
+    player,
+    [PlayPause, Next, Previous, ShuffleAll, StopAfterCurrent]
+);
 actions!(scan, [ForceScan, Scan]);
 actions!(hummingbird, [HideSelf, HideOthers, ShowAll]);
 actions!(help, [Discord, Patreon, Issues]);
@@ -47,6 +50,7 @@ pub fn register_actions(cx: &mut App) {
     cx.on_action(undo);
     cx.on_action(issues);
     cx.on_action(shuffle_all);
+    cx.on_action(stop_after_current);
     cx.on_action(scan);
     cx.on_action(open_log);
     cx.on_action(copy_troubleshooting_info);
@@ -80,6 +84,11 @@ pub fn register_actions(cx: &mut App) {
     cx.bind_keys([KeyBinding::new("alt-shift-s", ForceScan, None)]);
     cx.bind_keys([KeyBinding::new("alt-s", Scan, None)]);
     cx.bind_keys([KeyBinding::new("space", PlayPause, None)]);
+    cx.bind_keys([KeyBinding::new(
+        "ctrl-shift-space",
+        StopAfterCurrent,
+        Some("!TextInput"),
+    )]);
 
     let mut app_menu = MenuBuilder::new(tr!("APP_NAME"))
         .add_item(menu_item(
@@ -350,4 +359,9 @@ fn shuffle_all(_: &ShuffleAll, cx: &mut App) {
 fn undo(_: &Undo, cx: &mut App) {
     let interface = cx.global::<PlaybackInterface>();
     interface.undo();
+}
+
+fn stop_after_current(_: &StopAfterCurrent, cx: &mut App) {
+    let interface = cx.global::<PlaybackInterface>();
+    interface.stop_after_current();
 }

--- a/src/ui/models.rs
+++ b/src/ui/models.rs
@@ -130,6 +130,7 @@ pub struct PlaybackInfo {
     pub current_track: Entity<Option<CurrentTrack>>,
     pub shuffling: Entity<bool>,
     pub repeating: Entity<RepeatState>,
+    pub stop_after_current: Entity<bool>,
     pub volume: Entity<f64>,
     pub prev_volume: Entity<f64>,
 }
@@ -537,6 +538,7 @@ pub fn build_models(
     let current_track: Entity<Option<CurrentTrack>> = cx.new(|_| initial_track);
     let shuffling: Entity<bool> = cx.new(|_| initial_shuffle);
     let repeating: Entity<RepeatState> = cx.new(|_| initial_repeat);
+    let stop_after_current: Entity<bool> = cx.new(|_| false);
     let volume: Entity<f64> = cx.new(|_| storage_data.volume);
     let prev_volume: Entity<f64> = cx.new(|_| storage_data.volume);
 
@@ -547,6 +549,7 @@ pub fn build_models(
         current_track,
         shuffling,
         repeating,
+        stop_after_current,
         volume,
         prev_volume,
     });

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -41,6 +41,7 @@ pub struct Theme {
     pub playback_button_border: Rgba,
     pub playback_button_toggled: Rgba,
     pub playback_button_repeat_one: Rgba,
+    pub stop_after_current_indicator: Rgba,
 
     pub window_button: Rgba,
     pub window_button_hover: Rgba,
@@ -170,6 +171,7 @@ impl Default for Theme {
             playback_button_border: rgba(0x00000000),
             playback_button_toggled: rgb(0x688CF0),
             playback_button_repeat_one: rgb(0x63C58D),
+            stop_after_current_indicator: rgb(0xF0A868),
 
             window_button: rgba(0x00000000),
             window_button_hover: rgb(0x262D42),

--- a/translations/en.json
+++ b/translations/en.json
@@ -32,6 +32,7 @@
   "ACTION_SEARCH": "Search",
   "ACTION_SETTINGS": "Settings",
   "ACTION_SHUFFLE_ALL": "Shuffle All Tracks",
+  "ACTION_STOP_AFTER_CURRENT": "Stop After Current",
   "ACTION_UNDO_QUEUE": "Undo",
   "ADD_TO_PLAYLIST": "Add to playlist",
   "ADD_TO_QUEUE": "Add to queue",
@@ -240,6 +241,7 @@
     "one": "{{count}} track",
     "other": "{{count}} tracks"
   },
+  "STOP_AFTER_CURRENT_TOOLTIP": "Will stop after current track",
   "STOP_REPEATING": "Stop Repeating",
   "STOP_SHUFFLING": "Stop Shuffling",
   "TABLE_ALBUMS": "Albums",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -1,7 +1,7 @@
 {
   "ABOUT": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:86",
+    "definedIn": "src/ui/global_actions.rs:95",
     "plural": false,
     "description": null
   },
@@ -91,55 +91,55 @@
   },
   "ACTION_ABOUT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:183",
+    "definedIn": "src/ui/command_palette.rs:184",
     "plural": false,
     "description": null
   },
   "ACTION_CHECK_FOR_UPDATES": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:202",
+    "definedIn": "src/ui/command_palette.rs:203",
     "plural": false,
     "description": null
   },
   "ACTION_COPY_TROUBLESHOOTING_INFO": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:215",
+    "definedIn": "src/ui/command_palette.rs:216",
     "plural": false,
     "description": null
   },
   "ACTION_FORCESCAN": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:247",
+    "definedIn": "src/ui/command_palette.rs:254",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_HUMMINGBIRD": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:41",
+    "definedIn": "src/ui/command_palette.rs:42",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_PLAYBACK": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:42",
+    "definedIn": "src/ui/command_palette.rs:43",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_PLAYLIST": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:44",
+    "definedIn": "src/ui/command_palette.rs:45",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_QUEUE": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:43",
+    "definedIn": "src/ui/command_palette.rs:44",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_SCAN": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:45",
+    "definedIn": "src/ui/command_palette.rs:46",
     "plural": false,
     "description": null
   },
@@ -151,55 +151,61 @@
   },
   "ACTION_NEXT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:229",
+    "definedIn": "src/ui/command_palette.rs:230",
     "plural": false,
     "description": null
   },
   "ACTION_OPEN_LOG": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:208",
+    "definedIn": "src/ui/command_palette.rs:209",
     "plural": false,
     "description": null
   },
   "ACTION_PLAYPAUSE": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:223",
+    "definedIn": "src/ui/command_palette.rs:224",
     "plural": false,
     "description": null
   },
   "ACTION_PREVIOUS": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:235",
+    "definedIn": "src/ui/command_palette.rs:236",
     "plural": false,
     "description": null
   },
   "ACTION_QUIT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:177",
+    "definedIn": "src/ui/command_palette.rs:178",
     "plural": false,
     "description": null
   },
   "ACTION_SEARCH": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:189",
+    "definedIn": "src/ui/command_palette.rs:190",
     "plural": false,
     "description": null
   },
   "ACTION_SETTINGS": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:195",
+    "definedIn": "src/ui/command_palette.rs:196",
     "plural": false,
     "description": null
   },
   "ACTION_SHUFFLE_ALL": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:241",
+    "definedIn": "src/ui/command_palette.rs:242",
+    "plural": false,
+    "description": null
+  },
+  "ACTION_STOP_AFTER_CURRENT": {
+    "context": "command_palette.rs",
+    "definedIn": "src/ui/command_palette.rs:248",
     "plural": false,
     "description": null
   },
   "ACTION_UNDO_QUEUE": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:253",
+    "definedIn": "src/ui/command_palette.rs:260",
     "plural": false,
     "description": null
   },
@@ -355,7 +361,7 @@
   },
   "COMMAND_PALETTE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:197",
+    "definedIn": "src/ui/global_actions.rs:206",
     "plural": false,
     "description": null
   },
@@ -379,7 +385,7 @@
   },
   "DISCORD": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:155",
+    "definedIn": "src/ui/global_actions.rs:164",
     "plural": false,
     "description": null
   },
@@ -391,7 +397,7 @@
   },
   "EDIT": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:185",
+    "definedIn": "src/ui/global_actions.rs:194",
     "plural": false,
     "description": null
   },
@@ -415,13 +421,13 @@
   },
   "FILE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:180",
+    "definedIn": "src/ui/global_actions.rs:189",
     "plural": false,
     "description": null
   },
   "GITHUB_ISSUES": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:150",
+    "definedIn": "src/ui/global_actions.rs:159",
     "plural": false,
     "description": null
   },
@@ -445,19 +451,19 @@
   },
   "HELP": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:132",
+    "definedIn": "src/ui/global_actions.rs:141",
     "plural": false,
     "description": null
   },
   "HIDE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:111",
+    "definedIn": "src/ui/global_actions.rs:120",
     "plural": false,
     "description": null
   },
   "HIDE_OTHERS": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:116",
+    "definedIn": "src/ui/global_actions.rs:125",
     "plural": false,
     "description": null
   },
@@ -589,19 +595,19 @@
   },
   "LIBRARY_FORCE_RESCAN": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:221",
+    "definedIn": "src/ui/global_actions.rs:230",
     "plural": false,
     "description": null
   },
   "LIBRARY_SCAN": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:216",
+    "definedIn": "src/ui/global_actions.rs:225",
     "plural": false,
     "description": null
   },
   "LIBRARY_SHUFFLE_ALL": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:210",
+    "definedIn": "src/ui/global_actions.rs:219",
     "plural": false,
     "description": null
   },
@@ -631,13 +637,13 @@
   },
   "LYRICS": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:1040",
+    "definedIn": "src/ui/controls.rs:1070",
     "plural": false,
     "description": null
   },
   "MUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:975",
+    "definedIn": "src/ui/controls.rs:1005",
     "plural": false,
     "description": null
   },
@@ -649,7 +655,7 @@
   },
   "NEXT_TRACK": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:633",
+    "definedIn": "src/ui/controls.rs:663",
     "plural": false,
     "description": null
   },
@@ -667,7 +673,7 @@
   },
   "PATREON": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:172",
+    "definedIn": "src/ui/global_actions.rs:181",
     "plural": false,
     "description": null
   },
@@ -763,7 +769,7 @@
   },
   "PREVIOUS_TRACK": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:581",
+    "definedIn": "src/ui/controls.rs:594",
     "plural": false,
     "description": null
   },
@@ -775,7 +781,7 @@
   },
   "QUIT": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:127",
+    "definedIn": "src/ui/global_actions.rs:136",
     "plural": false,
     "description": null
   },
@@ -841,19 +847,19 @@
   },
   "REPEAT": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:711",
+    "definedIn": "src/ui/controls.rs:741",
     "plural": false,
     "description": null
   },
   "REPEAT_OFF": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:701",
+    "definedIn": "src/ui/controls.rs:731",
     "plural": false,
     "description": null
   },
   "REPEAT_ONE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:720",
+    "definedIn": "src/ui/controls.rs:750",
     "plural": false,
     "description": null
   },
@@ -1057,7 +1063,7 @@
   },
   "SEARCH": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:202",
+    "definedIn": "src/ui/global_actions.rs:211",
     "plural": false,
     "description": null
   },
@@ -1225,7 +1231,7 @@
   },
   "SHOW_ALL": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:121",
+    "definedIn": "src/ui/global_actions.rs:130",
     "plural": false,
     "description": null
   },
@@ -1337,15 +1343,21 @@
     "plural": true,
     "description": null
   },
+  "STOP_AFTER_CURRENT_TOOLTIP": {
+    "context": "controls.rs",
+    "definedIn": "src/ui/controls.rs:637",
+    "plural": false,
+    "description": null
+  },
   "STOP_REPEATING": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:679",
+    "definedIn": "src/ui/controls.rs:709",
     "plural": false,
     "description": null
   },
   "STOP_SHUFFLING": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:551",
+    "definedIn": "src/ui/controls.rs:564",
     "plural": false,
     "description": null
   },
@@ -1405,7 +1417,7 @@
   },
   "UNDO_QUEUE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:186",
+    "definedIn": "src/ui/global_actions.rs:195",
     "plural": false,
     "description": null
   },
@@ -1435,7 +1447,7 @@
   },
   "UNMUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:968",
+    "definedIn": "src/ui/controls.rs:998",
     "plural": false,
     "description": null
   },
@@ -1465,13 +1477,13 @@
   },
   "VIEW": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:192",
+    "definedIn": "src/ui/global_actions.rs:201",
     "plural": false,
     "description": "The View menu. Must *exactly* match the text required by macOS."
   },
   "WINDOW": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:233",
+    "definedIn": "src/ui/global_actions.rs:242",
     "plural": false,
     "description": "The Window menu. Must *exactly* match the text required by macOS."
   }

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -637,13 +637,13 @@
   },
   "LYRICS": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:1070",
+    "definedIn": "src/ui/controls.rs:1083",
     "plural": false,
     "description": null
   },
   "MUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:1005",
+    "definedIn": "src/ui/controls.rs:1018",
     "plural": false,
     "description": null
   },
@@ -655,7 +655,7 @@
   },
   "NEXT_TRACK": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:663",
+    "definedIn": "src/ui/controls.rs:676",
     "plural": false,
     "description": null
   },
@@ -847,19 +847,19 @@
   },
   "REPEAT": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:741",
+    "definedIn": "src/ui/controls.rs:754",
     "plural": false,
     "description": null
   },
   "REPEAT_OFF": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:731",
+    "definedIn": "src/ui/controls.rs:744",
     "plural": false,
     "description": null
   },
   "REPEAT_ONE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:750",
+    "definedIn": "src/ui/controls.rs:763",
     "plural": false,
     "description": null
   },
@@ -1345,13 +1345,13 @@
   },
   "STOP_AFTER_CURRENT_TOOLTIP": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:637",
+    "definedIn": "src/ui/controls.rs:641",
     "plural": false,
     "description": null
   },
   "STOP_REPEATING": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:709",
+    "definedIn": "src/ui/controls.rs:722",
     "plural": false,
     "description": null
   },
@@ -1447,7 +1447,7 @@
   },
   "UNMUTE": {
     "context": "controls.rs",
-    "definedIn": "src/ui/controls.rs:998",
+    "definedIn": "src/ui/controls.rs:1011",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
Closes #185 
<img width="1002" height="65" alt="image" src="https://github.com/user-attachments/assets/78daea48-04b0-427a-908a-5c73dad8b0e6" /> <- the indicator, there's not really any other better place for this and i like this anyways

## Changes
<!-- What specific changes were made? -->

## Testing
<!-- How did you test these changes? -->

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
