### PR TITLE
feat: add queue selection setting

### DIFF
--- a/src/settings/interface.rs
+++ b/src/settings/interface.rs
@@ -18,6 +18,10 @@ fn default_grid_min_item_width() -> f32 {
     DEFAULT_GRID_MIN_ITEM_WIDTH
 }
 
+fn default_queue_select_on_click() -> bool {
+    true
+}
+
 pub fn clamp_grid_min_item_width(value: f32) -> f32 {
     if !value.is_finite() {
         return DEFAULT_GRID_MIN_ITEM_WIDTH;
@@ -44,6 +48,8 @@ pub struct InterfaceSettings {
     pub reduced_motion: bool,
     #[serde(default)]
     pub always_show_scrollbars: bool,
+    #[serde(default = "default_queue_select_on_click")]
+    pub queue_select_on_click: bool,
     #[cfg(not(target_os = "macos"))]
     #[serde(default)]
     pub swap_menu_and_nav: bool,
@@ -81,6 +87,7 @@ impl Default for InterfaceSettings {
             grid_min_item_width: DEFAULT_GRID_MIN_ITEM_WIDTH,
             reduced_motion: false,
             always_show_scrollbars: false,
+            queue_select_on_click: true,
             #[cfg(not(target_os = "macos"))]
             swap_menu_and_nav: false,
         }

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -318,6 +318,13 @@ impl Render for QueueItem {
                                 let modifiers = event.modifiers();
                                 let ctrl = modifiers.control || modifiers.platform;
 
+                                let select_on_click = cx
+                                    .global::<SettingsGlobal>()
+                                    .model
+                                    .read(cx)
+                                    .interface
+                                    .queue_select_on_click;
+
                                 if event.click_count() == 2 {
                                     cx.global::<PlaybackInterface>().jump(idx);
                                 } else if ctrl {
@@ -325,8 +332,10 @@ impl Render for QueueItem {
                                 } else if modifiers.shift {
                                     selection
                                         .update(cx, |s, cx| s.shift_range(idx, Some(current), cx));
-                                } else {
+                                } else if select_on_click {
                                     selection.update(cx, |s, cx| s.select(idx, cx));
+                                } else {
+                                    cx.global::<PlaybackInterface>().jump(idx);
                                 }
                             })
                         })

--- a/src/ui/settings/interface.rs
+++ b/src/ui/settings/interface.rs
@@ -338,6 +338,27 @@ impl Render for InterfaceSettings {
                     "interface-always-show-scrollbars-check",
                     interface.always_show_scrollbars,
                 )),
+            )
+            .child(
+                label(
+                    "interface-queue-select-on-click",
+                    tr!("INTERFACE_QUEUE_SELECT_ON_CLICK", "Clicking on queue selects tracks"),
+                )
+                .subtext(tr!(
+                    "INTERFACE_QUEUE_SELECT_ON_CLICK_SUBTEXT",
+                    "Clicking on a queue item selects it, double clicking plays it."
+                ))
+                .cursor_pointer()
+                .w_full()
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.update_interface(cx, |interface| {
+                        interface.queue_select_on_click = !interface.queue_select_on_click;
+                    });
+                }))
+                .child(checkbox(
+                    "interface-queue-select-on-click-check",
+                    interface.queue_select_on_click,
+                )),
             );
 
         #[cfg(not(target_os = "macos"))]

--- a/translations/en.json
+++ b/translations/en.json
@@ -86,6 +86,8 @@
   "INTERFACE_FULL_WIDTH_LIBRARY_SUBTEXT": "Allows the library to take up the full width of the screen.",
   "INTERFACE_GRID_MIN_ITEM_WIDTH": "Grid item width",
   "INTERFACE_GRID_MIN_ITEM_WIDTH_SUBTEXT": "Adjusts the minimum width of items in grid view.",
+  "INTERFACE_QUEUE_SELECT_ON_CLICK": "Clicking on queue selects tracks",
+  "INTERFACE_QUEUE_SELECT_ON_CLICK_SUBTEXT": "Clicking on a queue item selects it, double clicking plays it.",
   "INTERFACE_REDUCED_MOTION": "Reduced motion",
   "INTERFACE_REDUCED_MOTION_SUBTEXT": "Disables smooth scrolling, fades, and other motion-heavy UI animations.",
   "INTERFACE_STARTUP_LIBRARY_VIEW": "Default startup view",

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -265,13 +265,13 @@
   },
   "CLEAR_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:786",
+    "definedIn": "src/ui/queue.rs:795",
     "plural": false,
     "description": null
   },
   "CLOSE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:797",
+    "definedIn": "src/ui/queue.rs:806",
     "plural": false,
     "description": null
   },
@@ -427,13 +427,13 @@
   },
   "GO_TO_ALBUM": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:548",
+    "definedIn": "src/ui/queue.rs:557",
     "plural": false,
     "description": null
   },
   "GO_TO_ARTIST": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:565",
+    "definedIn": "src/ui/queue.rs:574",
     "plural": false,
     "description": null
   },
@@ -503,6 +503,18 @@
     "plural": false,
     "description": null
   },
+  "INTERFACE_QUEUE_SELECT_ON_CLICK": {
+    "context": "interface.rs",
+    "definedIn": "src/ui/settings/interface.rs:345",
+    "plural": false,
+    "description": null
+  },
+  "INTERFACE_QUEUE_SELECT_ON_CLICK_SUBTEXT": {
+    "context": "interface.rs",
+    "definedIn": "src/ui/settings/interface.rs:348",
+    "plural": false,
+    "description": null
+  },
   "INTERFACE_REDUCED_MOTION": {
     "context": "interface.rs",
     "definedIn": "src/ui/settings/interface.rs:303",
@@ -529,13 +541,13 @@
   },
   "INTERFACE_SWAP_MENU_AND_NAV": {
     "context": "interface.rs",
-    "definedIn": "src/ui/settings/interface.rs:348",
+    "definedIn": "src/ui/settings/interface.rs:369",
     "plural": false,
     "description": null
   },
   "INTERFACE_SWAP_MENU_AND_NAV_SUBTEXT": {
     "context": "interface.rs",
-    "definedIn": "src/ui/settings/interface.rs:353",
+    "definedIn": "src/ui/settings/interface.rs:374",
     "plural": false,
     "description": null
   },
@@ -769,7 +781,7 @@
   },
   "QUEUE_TITLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:778",
+    "definedIn": "src/ui/queue.rs:787",
     "plural": false,
     "description": null
   },
@@ -811,7 +823,7 @@
   },
   "REMOVE_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:627",
+    "definedIn": "src/ui/queue.rs:636",
     "plural": false,
     "description": null
   },
@@ -823,7 +835,7 @@
   },
   "REMOVE_N_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:530",
+    "definedIn": "src/ui/queue.rs:539",
     "plural": true,
     "description": null
   },


### PR DESCRIPTION
## Summary
Allows the user to change the on-click behavior to the previous behavior of click-to-play. Default behavior is unchanged.

## Changes
Added a setting to change on click behavior

## Testing
I clicked on thing :)

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [x] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
