### PR TITLE
feat: add dragging new tracks into playlists

### DIFF
--- a/src/ui/components/drag_drop.rs
+++ b/src/ui/components/drag_drop.rs
@@ -17,7 +17,6 @@ pub enum DropPosition {
 #[derive(Clone, Debug)]
 pub struct DragData {
     pub source_index: usize,
-    pub additional_indices: Vec<usize>,
     pub list_id: ElementId,
 }
 
@@ -25,26 +24,12 @@ impl DragData {
     pub fn new(source_index: usize, list_id: impl Into<ElementId>) -> Self {
         Self {
             source_index,
-            additional_indices: Vec::new(),
             list_id: list_id.into(),
         }
     }
-
-    pub fn with_additional_indices(mut self, indices: Vec<usize>) -> Self {
-        self.additional_indices = indices;
-        self
-    }
-
-    pub fn all_indices(&self) -> Vec<usize> {
-        let mut all = vec![self.source_index];
-        all.extend_from_slice(&self.additional_indices);
-        all.sort_unstable();
-        all.dedup();
-        all
-    }
 }
 
-/// Drag data for individual tracks that can be dropped onto the queue.
+/// Drag data for individual tracks that can be dropped onto the queue or playlists.
 /// Also supports reordering when source_list_id and source_index are provided.
 #[derive(Clone, Debug)]
 pub struct TrackDragData {
@@ -52,12 +37,26 @@ pub struct TrackDragData {
     pub album_id: Option<i64>,
     pub path: PathBuf,
     pub display_name: SharedString,
-    /// Source list ID, if dragged from a reorderable list (e.g. a playlist).
+    /// Source list ID, if dragged from a reorderable list (e.g. a playlist or the queue).
     pub source_list_id: Option<ElementId>,
     pub source_index: Option<usize>,
+    /// Additional selected indices when dragging multiple items from a list.
+    pub additional_indices: Vec<usize>,
 }
 
 impl TrackDragData {
+    pub fn new(path: impl Into<PathBuf>, display_name: impl Into<SharedString>) -> Self {
+        Self {
+            track_id: None,
+            album_id: None,
+            path: path.into(),
+            display_name: display_name.into(),
+            source_list_id: None,
+            source_index: None,
+            additional_indices: Vec::new(),
+        }
+    }
+
     pub fn from_track(
         track_id: i64,
         album_id: Option<i64>,
@@ -71,6 +70,7 @@ impl TrackDragData {
             display_name: display_name.into(),
             source_list_id: None,
             source_index: None,
+            additional_indices: Vec::new(),
         }
     }
 
@@ -78,6 +78,20 @@ impl TrackDragData {
         self.source_list_id = Some(list_id.into());
         self.source_index = Some(index);
         self
+    }
+
+    pub fn with_additional_indices(mut self, indices: Vec<usize>) -> Self {
+        self.additional_indices = indices;
+        self
+    }
+
+    /// All indices being dragged (source_index + additional_indices), sorted and deduped.
+    pub fn all_indices(&self) -> Vec<usize> {
+        let mut all = self.source_index.into_iter().collect::<Vec<_>>();
+        all.extend_from_slice(&self.additional_indices);
+        all.sort_unstable();
+        all.dedup();
+        all
     }
 }
 
@@ -454,13 +468,13 @@ pub fn handle_drag_move<V: 'static>(
         return false;
     }
 
-    let all_indices = drag_data.all_indices();
+    let source_index = drag_data.source_index;
     let mouse_pos = event.event.position;
     let container_bounds = event.bounds;
 
     manager.update(cx, |m, _| {
         m.state.is_dragging = true;
-        m.state.dragging_indices = all_indices;
+        m.state.dragging_indices = vec![source_index];
         m.state.set_mouse_y(mouse_pos.y);
         m.container_bounds = Some(container_bounds);
     });
@@ -497,9 +511,10 @@ pub fn handle_drag_move<V: 'static>(
     scrolled
 }
 
-/// Handle a drag move event for TrackDragData in a reorderable list.
+/// Handle a drag move event for TrackDragData in a list.
 ///
-/// Only processes the event if the drag originated from the same list (source_list_id matches).
+/// Works for both internal reordering (when source_list_id matches) and external
+/// drops (when the drag originated from another list or component).
 /// Returns `true` if scrolling occurred.
 pub fn handle_track_drag_move<V: 'static>(
     manager: Entity<DragDropListManager>,
@@ -518,20 +533,18 @@ pub fn handle_track_drag_move<V: 'static>(
         .map(|id| *id == config.list_id)
         .unwrap_or(false);
 
-    if !is_internal {
-        return false;
-    }
-
-    let Some(source_index) = drag_data.source_index else {
-        return false;
-    };
-
     let mouse_pos = event.event.position;
     let container_bounds = event.bounds;
 
+    let dragging_indices = if is_internal {
+        drag_data.all_indices()
+    } else {
+        Vec::new()
+    };
+
     manager.update(cx, |m, _| {
         m.state.is_dragging = true;
-        m.state.dragging_indices = vec![source_index];
+        m.state.dragging_indices = dragging_indices;
         m.state.set_mouse_y(mouse_pos.y);
         m.container_bounds = Some(container_bounds);
     });
@@ -596,37 +609,6 @@ pub fn handle_drop<V: 'static, F>(
     manager.update(cx, |m, _| m.state.end_drag());
 }
 
-/// Handle a drop of DragData with potential multi-selection indices.
-/// Like `handle_drop`, but calls `on_multi_reorder` with the full DragData
-/// so the caller can dispatch single vs. multi-item moves.
-pub fn handle_drop_multi<V: 'static, F>(
-    manager: Entity<DragDropListManager>,
-    drag_data: &DragData,
-    cx: &mut Context<V>,
-    on_multi_reorder: F,
-) where
-    F: FnOnce(&DragData, usize, &mut Context<V>),
-{
-    let config_list_id = manager.read(cx).config.list_id.clone();
-
-    if drag_data.list_id != config_list_id {
-        return;
-    }
-
-    let target = manager.read(cx).state.drop_target;
-
-    if let Some((target_index, position)) = target {
-        let final_target = calculate_move_target(drag_data.source_index, target_index, position);
-
-        let is_multi = !drag_data.additional_indices.is_empty();
-        if is_multi || drag_data.source_index != final_target {
-            on_multi_reorder(drag_data, final_target, cx);
-        }
-    }
-
-    manager.update(cx, |m, _| m.state.end_drag());
-}
-
 /// Handle a drop of TrackDragData for reordering within a list.
 ///
 /// Only processes the drop if it originated from the same list (source_list_id matches).
@@ -670,6 +652,98 @@ pub fn handle_track_drop<V: 'static, F>(
     }
 
     manager.update(cx, |m, _| m.state.end_drag());
+}
+
+/// Handle a drop of TrackDragData with potential multi-selection indices.
+///
+/// Like `handle_track_drop`, but calls `on_multi_reorder` with the full
+/// `TrackDragData` so the caller can dispatch single vs. multi-item moves.
+pub fn handle_track_drop_multi<V: 'static, F>(
+    manager: Entity<DragDropListManager>,
+    drag_data: &TrackDragData,
+    cx: &mut Context<V>,
+    on_multi_reorder: F,
+) where
+    F: FnOnce(&TrackDragData, usize, &mut Context<V>),
+{
+    let config_list_id = manager.read(cx).config.list_id.clone();
+
+    let is_internal = drag_data
+        .source_list_id
+        .as_ref()
+        .map(|id| *id == config_list_id)
+        .unwrap_or(false);
+
+    if !is_internal {
+        manager.update(cx, |m, _| m.state.end_drag());
+        return;
+    }
+
+    let target = manager.read(cx).state.drop_target;
+
+    if let Some((target_index, position)) = target {
+        let source_index = drag_data.source_index.unwrap_or(0);
+        let final_target = calculate_move_target(source_index, target_index, position);
+
+        let is_multi = !drag_data.additional_indices.is_empty();
+        if is_multi || source_index != final_target {
+            on_multi_reorder(drag_data, final_target, cx);
+        }
+    }
+
+    manager.update(cx, |m, _| m.state.end_drag());
+}
+
+/// Updates drag-drop state for an external drag (e.g. AlbumDragData).
+///
+/// Computes drop target, performs edge scrolling, and returns `true` if scrolling occurred.
+/// Does not populate `dragging_indices`.
+pub fn handle_external_drag_move<V: 'static>(
+    manager: Entity<DragDropListManager>,
+    scroll_handle: ScrollableHandle,
+    mouse_pos: Point<Pixels>,
+    container_bounds: Bounds<Pixels>,
+    item_count: usize,
+    cx: &mut Context<V>,
+    reduced_motion: bool,
+) -> bool {
+    let config = manager.read(cx).config.clone();
+
+    manager.update(cx, |m, _| {
+        m.state.is_dragging = true;
+        m.state.dragging_indices.clear();
+        m.state.set_mouse_y(mouse_pos.y);
+        m.container_bounds = Some(container_bounds);
+    });
+
+    let direction = get_edge_scroll_direction(mouse_pos.y, container_bounds, &config.scroll_config);
+    let scrolled = if reduced_motion {
+        false
+    } else {
+        perform_edge_scroll(&scroll_handle, direction, &config.scroll_config)
+    };
+
+    if container_bounds.contains(&mouse_pos) {
+        let scroll_offset_y = scroll_handle.offset().y;
+        let drop_target = calculate_drop_target(
+            mouse_pos,
+            container_bounds,
+            scroll_offset_y,
+            config.item_height,
+            item_count,
+        );
+        manager.update(cx, |m, _| {
+            if let Some((item_index, drop_position)) = drop_target {
+                m.state.update_drop_target(item_index, drop_position);
+            } else {
+                m.state.clear_drop_target();
+            }
+        });
+    } else {
+        manager.update(cx, |m, _| m.state.clear_drop_target());
+    }
+
+    scrolled
 }
 
 pub fn check_drag_cancelled<V: 'static>(

--- a/src/ui/library/playlist_view.rs
+++ b/src/ui/library/playlist_view.rs
@@ -25,7 +25,7 @@ use crate::{
             button::{ButtonSize, button},
             drag_drop::{
                 AlbumDragData, DragDropItemState, DragDropListConfig, DragDropListManager,
-                DragPreview, DropIndicator, TrackDragData, check_drag_cancelled,
+                DragPreview, DropIndicator, DropPosition, TrackDragData, check_drag_cancelled,
                 continue_edge_scroll, handle_external_drag_move, handle_track_drag_move,
                 handle_track_drop,
             },
@@ -402,6 +402,84 @@ impl PlaylistView {
         matches!(self.sort_method, PlaylistTrackSortMethod::Custom)
     }
 
+    fn resolve_target_position(
+        &self,
+        drop_target: Option<(usize, DropPosition)>,
+        cx: &mut Context<Self>,
+    ) -> Option<i64> {
+        let playlist_track_ids = self.playlist_track_ids.clone();
+        drop_target.and_then(|(target_index, position)| {
+            if playlist_track_ids.is_empty() {
+                return None;
+            }
+            if target_index < playlist_track_ids.len() {
+                let target_item_id = playlist_track_ids[target_index].0;
+                let target_item = cx.get_playlist_item(target_item_id).ok()?;
+                Some(match position {
+                    DropPosition::Before => target_item.position,
+                    DropPosition::After => target_item.position + 1,
+                })
+            } else {
+                let last_item_id = playlist_track_ids.last()?.0;
+                let last_item = cx.get_playlist_item(last_item_id).ok()?;
+                Some(last_item.position + 1)
+            }
+        })
+    }
+
+    fn add_tracks_to_playlist(
+        &mut self,
+        track_ids: Vec<i64>,
+        target_position: Option<i64>,
+        cx: &mut Context<Self>,
+    ) {
+        let playlist_id = self.playlist.id;
+        let pool = cx.global::<Pool>().0.clone();
+        let playlist_tracker = cx.global::<Models>().playlist_tracker.clone();
+
+        cx.spawn(async move |_, cx| {
+            let pool_for_add = pool.clone();
+            let task = crate::RUNTIME.spawn(async move {
+                let mut new_item_ids: Vec<i64> = Vec::new();
+                for track_id in track_ids {
+                    let item_id =
+                        db::add_playlist_item(&pool_for_add, playlist_id, track_id).await?;
+                    new_item_ids.push(item_id);
+                }
+                Ok::<Vec<i64>, sqlx::Error>(new_item_ids)
+            });
+
+            let new_item_ids = match task.await {
+                Ok(Ok(ids)) => ids,
+                Ok(Err(err)) => {
+                    error!("could not add tracks to playlist: {err:?}");
+                    return;
+                }
+                Err(err) => {
+                    error!("add tracks to playlist task panicked: {err:?}");
+                    return;
+                }
+            };
+
+            if let Some(pos) = target_position {
+                for &item_id in new_item_ids.iter().rev() {
+                    let pool_for_move = pool.clone();
+                    let _ =
+                        crate::RUNTIME
+                            .spawn(async move {
+                                db::move_playlist_item(&pool_for_move, item_id, pos).await
+                            })
+                            .await;
+                }
+            }
+
+            playlist_tracker.update(cx, |_, cx| {
+                cx.emit(PlaylistEvent::PlaylistUpdated(playlist_id));
+            });
+        })
+        .detach();
+    }
+
     fn schedule_edge_scroll(
         manager: Entity<DragDropListManager>,
         scroll_handle: ScrollableHandle,
@@ -752,8 +830,6 @@ impl Render for PlaylistView {
                             ))
                             .on_drop(cx.listener(
                                 move |this: &mut PlaylistView, drag_data: &TrackDragData, _, cx| {
-                                    use crate::ui::components::drag_drop::DropPosition;
-
                                     let is_internal = drag_data
                                         .source_list_id
                                         .as_ref()
@@ -798,65 +874,9 @@ impl Render for PlaylistView {
                                             },
                                         );
                                     } else if let Some(track_id) = drag_data.track_id {
-                                        let playlist_id = this.playlist.id;
                                         let drop_target = this.drag_drop_manager.read(cx).state.drop_target;
-                                        let playlist_track_ids = this.playlist_track_ids.clone();
-
-                                        let target_position = drop_target.and_then(|(target_index, position)| {
-                                            if playlist_track_ids.is_empty() {
-                                                return None;
-                                            }
-                                            if target_index < playlist_track_ids.len() {
-                                                let target_item_id = playlist_track_ids[target_index].0;
-                                                let target_item = cx.get_playlist_item(target_item_id).ok()?;
-                                                Some(match position {
-                                                    DropPosition::Before => target_item.position,
-                                                    DropPosition::After => target_item.position + 1,
-                                                })
-                                            } else {
-                                                let last_item_id = playlist_track_ids.last()?.0;
-                                                let last_item = cx.get_playlist_item(last_item_id).ok()?;
-                                                Some(last_item.position + 1)
-                                            }
-                                        });
-
-                                        let pool = cx.global::<Pool>().0.clone();
-                                        let playlist_tracker =
-                                            cx.global::<Models>().playlist_tracker.clone();
-
-                                        cx.spawn(async move |_, cx| {
-                                            let pool_for_add = pool.clone();
-                                            let task = crate::RUNTIME.spawn(async move {
-                                                db::add_playlist_item(&pool_for_add, playlist_id, track_id).await
-                                            });
-
-                                            let new_item_id = match task.await {
-                                                Ok(Ok(id)) => id,
-                                                Ok(Err(err)) => {
-                                                    error!("could not add track to playlist: {err:?}");
-                                                    return;
-                                                }
-                                                Err(err) => {
-                                                    error!("add track to playlist task panicked: {err:?}");
-                                                    return;
-                                                }
-                                            };
-
-                                            if let Some(pos) = target_position {
-                                                let pool_for_move = pool.clone();
-                                                let _ = crate::RUNTIME
-                                                    .spawn(async move {
-                                                        db::move_playlist_item(&pool_for_move, new_item_id, pos).await
-                                                    })
-                                                    .await;
-                                            }
-
-                                            playlist_tracker.update(cx, |_, cx| {
-                                                cx.emit(PlaylistEvent::PlaylistUpdated(playlist_id));
-                                            });
-                                        })
-                                        .detach();
-
+                                        let target_position = this.resolve_target_position(drop_target, cx);
+                                        this.add_tracks_to_playlist(vec![track_id], target_position, cx);
                                         this.drag_drop_manager.update(cx, |m, _| m.state.end_drag());
                                     } else {
                                         this.drag_drop_manager.update(cx, |m, _| m.state.end_drag());
@@ -866,80 +886,12 @@ impl Render for PlaylistView {
                             ))
                             .on_drop(cx.listener(
                                 move |this: &mut PlaylistView, drag_data: &AlbumDragData, _, cx| {
-                                    use crate::ui::components::drag_drop::DropPosition;
-
-                                    let playlist_id = this.playlist.id;
                                     let drop_target = this.drag_drop_manager.read(cx).state.drop_target;
-                                    let playlist_track_ids = this.playlist_track_ids.clone();
-
-                                    let target_position = drop_target.and_then(|(target_index, position)| {
-                                        if playlist_track_ids.is_empty() {
-                                            return None;
-                                        }
-                                        if target_index < playlist_track_ids.len() {
-                                            let target_item_id = playlist_track_ids[target_index].0;
-                                            let target_item = cx.get_playlist_item(target_item_id).ok()?;
-                                            Some(match position {
-                                                DropPosition::Before => target_item.position,
-                                                DropPosition::After => target_item.position + 1,
-                                            })
-                                        } else {
-                                            let last_item_id = playlist_track_ids.last()?.0;
-                                            let last_item = cx.get_playlist_item(last_item_id).ok()?;
-                                            Some(last_item.position + 1)
-                                        }
-                                    });
+                                    let target_position = this.resolve_target_position(drop_target, cx);
 
                                     if let Ok(tracks) = cx.list_tracks_in_album(drag_data.album_id) {
-                                        let pool = cx.global::<Pool>().0.clone();
-                                        let playlist_tracker =
-                                            cx.global::<Models>().playlist_tracker.clone();
-
-                                        cx.spawn(async move |_, cx| {
-                                            let pool_for_add = pool.clone();
-                                            let task = crate::RUNTIME.spawn(async move {
-                                                let mut new_item_ids: Vec<i64> = Vec::new();
-                                                for track in tracks.iter() {
-                                                    let item_id = db::add_playlist_item(
-                                                        &pool_for_add,
-                                                        playlist_id,
-                                                        track.id,
-                                                    )
-                                                    .await?;
-                                                    new_item_ids.push(item_id);
-                                                }
-                                                Ok::<Vec<i64>, sqlx::Error>(new_item_ids)
-                                            });
-
-                                            let new_item_ids = match task.await {
-                                                Ok(Ok(ids)) => ids,
-                                                Ok(Err(err)) => {
-                                                    error!("could not add album tracks to playlist: {err:?}");
-                                                    return;
-                                                }
-                                                Err(err) => {
-                                                    error!("add album tracks to playlist task panicked: {err:?}");
-                                                    return;
-                                                }
-                                            };
-
-                                            if let Some(pos) = target_position {
-                                                for &item_id in new_item_ids.iter().rev() {
-                                                    let pool_for_move = pool.clone();
-                                                    let _ = crate::RUNTIME
-                                                        .spawn(async move {
-                                                            db::move_playlist_item(&pool_for_move, item_id, pos)
-                                                                .await
-                                                        })
-                                                        .await;
-                                                }
-                                            }
-
-                                            playlist_tracker.update(cx, |_, cx| {
-                                                cx.emit(PlaylistEvent::PlaylistUpdated(playlist_id));
-                                            });
-                                        })
-                                        .detach();
+                                        let track_ids: Vec<i64> = tracks.iter().map(|t| t.id).collect();
+                                        this.add_tracks_to_playlist(track_ids, target_position, cx);
                                     }
 
                                     this.drag_drop_manager.update(cx, |m, _| m.state.end_drag());

--- a/src/ui/library/playlist_view.rs
+++ b/src/ui/library/playlist_view.rs
@@ -12,20 +12,22 @@ use tracing::error;
 
 use crate::{
     library::{
-        db::{LibraryAccess, PlaylistTrackSortMethod},
+        db::{self, LibraryAccess, PlaylistTrackSortMethod},
         playlist::export_playlist,
         types::{Playlist, PlaylistType},
     },
     playback::queue::QueueItemData,
     ui::{
+        app::Pool,
         caching::hummingbird_cache,
         command_palette::{CommandCategory, CommandManager, CommandSpec},
         components::{
             button::{ButtonSize, button},
             drag_drop::{
-                DragDropItemState, DragDropListConfig, DragDropListManager, DragPreview,
-                DropIndicator, TrackDragData, check_drag_cancelled, continue_edge_scroll,
-                handle_track_drag_move, handle_track_drop,
+                AlbumDragData, DragDropItemState, DragDropListConfig, DragDropListManager,
+                DragPreview, DropIndicator, TrackDragData, check_drag_cancelled,
+                continue_edge_scroll, handle_external_drag_move, handle_track_drag_move,
+                handle_track_drop,
             },
             dropdown::dropdown,
             icons::{PLAYLIST, SORT_ASCENDING, SORT_DESCENDING, STAR, icon},
@@ -151,7 +153,13 @@ impl Render for PlaylistTrackItem {
             .w_full()
             .h(px(PLAYLIST_ITEM_HEIGHT))
             .relative()
-            .when(item_state.is_being_dragged, |d| d.opacity(0.5));
+            .when(item_state.is_being_dragged, |d| d.opacity(0.5))
+            .drag_over::<TrackDragData>(move |style, _, _, _| style.bg(rgba(0x88888822)))
+            .child(DropIndicator::with_state(
+                item_state.is_drop_target_before,
+                item_state.is_drop_target_after,
+                theme.button_primary,
+            ));
 
         if self.drag_enabled {
             let drag_data = TrackDragData::from_track(
@@ -162,16 +170,9 @@ impl Render for PlaylistTrackItem {
             )
             .with_reorder_info(self.list_id.clone(), idx);
 
-            element = element
-                .on_drag(drag_data, move |_, _, _, cx| {
-                    DragPreview::new(cx, track_title.clone())
-                })
-                .drag_over::<TrackDragData>(move |style, _, _, _| style.bg(rgba(0x88888822)))
-                .child(DropIndicator::with_state(
-                    item_state.is_drop_target_before,
-                    item_state.is_drop_target_after,
-                    theme.button_primary,
-                ));
+            element = element.on_drag(drag_data, move |_, _, _, cx| {
+                DragPreview::new(cx, track_title.clone())
+            });
         }
 
         element.child(self.track_item.clone())
@@ -654,55 +655,112 @@ impl Render for PlaylistView {
                             .h_full()
                             .relative()
                             .mt(px(18.0))
-                            .when(is_custom_sort, |this| {
-                                this.on_drag_move::<TrackDragData>(cx.listener(
-                                    move |this: &mut PlaylistView,
-                                          event: &DragMoveEvent<TrackDragData>,
-                                          window,
-                                          cx| {
+                            .on_drag_move::<TrackDragData>(cx.listener(
+                                move |this: &mut PlaylistView,
+                                      event: &DragMoveEvent<TrackDragData>,
+                                      window,
+                                      cx| {
+                                    let scroll_handle: ScrollableHandle =
+                                        this.scroll_handle.clone().into();
+
+                                    let reduced_motion = cx
+                                        .global::<crate::settings::SettingsGlobal>()
+                                        .model
+                                        .read(cx)
+                                        .interface
+                                        .reduced_motion;
+                                    let scrolled = handle_track_drag_move(
+                                        this.drag_drop_manager.clone(),
+                                        scroll_handle,
+                                        event,
+                                        item_count,
+                                        cx,
+                                        reduced_motion,
+                                    );
+
+                                    if scrolled {
+                                        let entity = cx.entity().downgrade();
+                                        let manager = this.drag_drop_manager.clone();
                                         let scroll_handle: ScrollableHandle =
                                             this.scroll_handle.clone().into();
 
-                                        let reduced_motion = cx
-                                            .global::<crate::settings::SettingsGlobal>()
-                                            .model
-                                            .read(cx)
-                                            .interface
-                                            .reduced_motion;
-                                        let scrolled = handle_track_drag_move(
-                                            this.drag_drop_manager.clone(),
-                                            scroll_handle,
-                                            event,
-                                            item_count,
-                                            cx,
-                                            reduced_motion,
-                                        );
+                                        window.on_next_frame(move |window, cx| {
+                                            if let Some(entity) = entity.upgrade() {
+                                                entity.update(cx, |_, cx| {
+                                                    Self::schedule_edge_scroll(
+                                                        manager,
+                                                        scroll_handle,
+                                                        window,
+                                                        cx,
+                                                    );
+                                                });
+                                            }
+                                        });
+                                    }
 
-                                        if scrolled {
-                                            let entity = cx.entity().downgrade();
-                                            let manager = this.drag_drop_manager.clone();
-                                            let scroll_handle: ScrollableHandle =
-                                                this.scroll_handle.clone().into();
+                                    cx.notify();
+                                },
+                            ))
+                            .on_drag_move::<AlbumDragData>(cx.listener(
+                                move |this: &mut PlaylistView,
+                                      event: &DragMoveEvent<AlbumDragData>,
+                                      window,
+                                      cx| {
+                                    let scroll_handle: ScrollableHandle =
+                                        this.scroll_handle.clone().into();
+                                    let mouse_pos = event.event.position;
+                                    let container_bounds = event.bounds;
 
-                                            window.on_next_frame(move |window, cx| {
-                                                if let Some(entity) = entity.upgrade() {
-                                                    entity.update(cx, |_, cx| {
-                                                        Self::schedule_edge_scroll(
-                                                            manager,
-                                                            scroll_handle,
-                                                            window,
-                                                            cx,
-                                                        );
-                                                    });
-                                                }
-                                            });
-                                        }
+                                    let reduced_motion = cx
+                                        .global::<crate::settings::SettingsGlobal>()
+                                        .model
+                                        .read(cx)
+                                        .interface
+                                        .reduced_motion;
+                                    let scrolled = handle_external_drag_move(
+                                        this.drag_drop_manager.clone(),
+                                        scroll_handle,
+                                        mouse_pos,
+                                        container_bounds,
+                                        item_count,
+                                        cx,
+                                        reduced_motion,
+                                    );
 
-                                        cx.notify();
-                                    },
-                                ))
-                                .on_drop(cx.listener(
-                                    move |this: &mut PlaylistView, drag_data: &TrackDragData, _, cx| {
+                                    if scrolled {
+                                        let entity = cx.entity().downgrade();
+                                        let manager = this.drag_drop_manager.clone();
+                                        let scroll_handle: ScrollableHandle =
+                                            this.scroll_handle.clone().into();
+
+                                        window.on_next_frame(move |window, cx| {
+                                            if let Some(entity) = entity.upgrade() {
+                                                entity.update(cx, |_, cx| {
+                                                    Self::schedule_edge_scroll(
+                                                        manager,
+                                                        scroll_handle,
+                                                        window,
+                                                        cx,
+                                                    );
+                                                });
+                                            }
+                                        });
+                                    }
+
+                                    cx.notify();
+                                },
+                            ))
+                            .on_drop(cx.listener(
+                                move |this: &mut PlaylistView, drag_data: &TrackDragData, _, cx| {
+                                    use crate::ui::components::drag_drop::DropPosition;
+
+                                    let is_internal = drag_data
+                                        .source_list_id
+                                        .as_ref()
+                                        .map(|id| *id == this.list_id)
+                                        .unwrap_or(false);
+
+                                    if is_internal && this.is_custom_sort() {
                                         let playlist_track_ids = this.playlist_track_ids.clone();
                                         let playlist_id = this.playlist.id;
 
@@ -739,10 +797,155 @@ impl Render for PlaylistView {
                                                 });
                                             },
                                         );
-                                        cx.notify();
-                                    },
-                                ))
-                            })
+                                    } else if let Some(track_id) = drag_data.track_id {
+                                        let playlist_id = this.playlist.id;
+                                        let drop_target = this.drag_drop_manager.read(cx).state.drop_target;
+                                        let playlist_track_ids = this.playlist_track_ids.clone();
+
+                                        let target_position = drop_target.and_then(|(target_index, position)| {
+                                            if playlist_track_ids.is_empty() {
+                                                return None;
+                                            }
+                                            if target_index < playlist_track_ids.len() {
+                                                let target_item_id = playlist_track_ids[target_index].0;
+                                                let target_item = cx.get_playlist_item(target_item_id).ok()?;
+                                                Some(match position {
+                                                    DropPosition::Before => target_item.position,
+                                                    DropPosition::After => target_item.position + 1,
+                                                })
+                                            } else {
+                                                let last_item_id = playlist_track_ids.last()?.0;
+                                                let last_item = cx.get_playlist_item(last_item_id).ok()?;
+                                                Some(last_item.position + 1)
+                                            }
+                                        });
+
+                                        let pool = cx.global::<Pool>().0.clone();
+                                        let playlist_tracker =
+                                            cx.global::<Models>().playlist_tracker.clone();
+
+                                        cx.spawn(async move |_, cx| {
+                                            let pool_for_add = pool.clone();
+                                            let task = crate::RUNTIME.spawn(async move {
+                                                db::add_playlist_item(&pool_for_add, playlist_id, track_id).await
+                                            });
+
+                                            let new_item_id = match task.await {
+                                                Ok(Ok(id)) => id,
+                                                Ok(Err(err)) => {
+                                                    error!("could not add track to playlist: {err:?}");
+                                                    return;
+                                                }
+                                                Err(err) => {
+                                                    error!("add track to playlist task panicked: {err:?}");
+                                                    return;
+                                                }
+                                            };
+
+                                            if let Some(pos) = target_position {
+                                                let pool_for_move = pool.clone();
+                                                let _ = crate::RUNTIME
+                                                    .spawn(async move {
+                                                        db::move_playlist_item(&pool_for_move, new_item_id, pos).await
+                                                    })
+                                                    .await;
+                                            }
+
+                                            playlist_tracker.update(cx, |_, cx| {
+                                                cx.emit(PlaylistEvent::PlaylistUpdated(playlist_id));
+                                            });
+                                        })
+                                        .detach();
+
+                                        this.drag_drop_manager.update(cx, |m, _| m.state.end_drag());
+                                    } else {
+                                        this.drag_drop_manager.update(cx, |m, _| m.state.end_drag());
+                                    }
+                                    cx.notify();
+                                },
+                            ))
+                            .on_drop(cx.listener(
+                                move |this: &mut PlaylistView, drag_data: &AlbumDragData, _, cx| {
+                                    use crate::ui::components::drag_drop::DropPosition;
+
+                                    let playlist_id = this.playlist.id;
+                                    let drop_target = this.drag_drop_manager.read(cx).state.drop_target;
+                                    let playlist_track_ids = this.playlist_track_ids.clone();
+
+                                    let target_position = drop_target.and_then(|(target_index, position)| {
+                                        if playlist_track_ids.is_empty() {
+                                            return None;
+                                        }
+                                        if target_index < playlist_track_ids.len() {
+                                            let target_item_id = playlist_track_ids[target_index].0;
+                                            let target_item = cx.get_playlist_item(target_item_id).ok()?;
+                                            Some(match position {
+                                                DropPosition::Before => target_item.position,
+                                                DropPosition::After => target_item.position + 1,
+                                            })
+                                        } else {
+                                            let last_item_id = playlist_track_ids.last()?.0;
+                                            let last_item = cx.get_playlist_item(last_item_id).ok()?;
+                                            Some(last_item.position + 1)
+                                        }
+                                    });
+
+                                    if let Ok(tracks) = cx.list_tracks_in_album(drag_data.album_id) {
+                                        let pool = cx.global::<Pool>().0.clone();
+                                        let playlist_tracker =
+                                            cx.global::<Models>().playlist_tracker.clone();
+
+                                        cx.spawn(async move |_, cx| {
+                                            let pool_for_add = pool.clone();
+                                            let task = crate::RUNTIME.spawn(async move {
+                                                let mut new_item_ids: Vec<i64> = Vec::new();
+                                                for track in tracks.iter() {
+                                                    let item_id = db::add_playlist_item(
+                                                        &pool_for_add,
+                                                        playlist_id,
+                                                        track.id,
+                                                    )
+                                                    .await?;
+                                                    new_item_ids.push(item_id);
+                                                }
+                                                Ok::<Vec<i64>, sqlx::Error>(new_item_ids)
+                                            });
+
+                                            let new_item_ids = match task.await {
+                                                Ok(Ok(ids)) => ids,
+                                                Ok(Err(err)) => {
+                                                    error!("could not add album tracks to playlist: {err:?}");
+                                                    return;
+                                                }
+                                                Err(err) => {
+                                                    error!("add album tracks to playlist task panicked: {err:?}");
+                                                    return;
+                                                }
+                                            };
+
+                                            if let Some(pos) = target_position {
+                                                for &item_id in new_item_ids.iter().rev() {
+                                                    let pool_for_move = pool.clone();
+                                                    let _ = crate::RUNTIME
+                                                        .spawn(async move {
+                                                            db::move_playlist_item(&pool_for_move, item_id, pos)
+                                                                .await
+                                                        })
+                                                        .await;
+                                                }
+                                            }
+
+                                            playlist_tracker.update(cx, |_, cx| {
+                                                cx.emit(PlaylistEvent::PlaylistUpdated(playlist_id));
+                                            });
+                                        })
+                                        .detach();
+                                    }
+
+                                    this.drag_drop_manager.update(cx, |m, _| m.state.end_drag());
+                                    cx.notify();
+                                },
+                            ))
                             .child(
                                 uniform_list("playlist-list", items_clone.len(), move |range, _, cx| {
                                     let start = range.start;

--- a/src/ui/library/sidebar/playlists.rs
+++ b/src/ui/library/sidebar/playlists.rs
@@ -22,9 +22,9 @@ use crate::{
             button::{ButtonIntent, button},
             context::context,
             drag_drop::{
-                AlbumDragData, DragData, DragDropItemState, DragDropListConfig, DragDropListManager,
-                DragPreview, DropIndicator, TrackDragData, check_drag_cancelled, handle_drag_move,
-                handle_drop,
+                AlbumDragData, DragData, DragDropItemState, DragDropListConfig,
+                DragDropListManager, DragPreview, DropIndicator, TrackDragData,
+                check_drag_cancelled, handle_drag_move, handle_drop,
             },
             icons::{CROSS, FILE_EXPORT, PENCIL, PLAY, PLAYLIST, PLUS, SHUFFLE, STAR},
             menu::{menu, menu_item, menu_separator},
@@ -350,14 +350,11 @@ impl Render for PlaylistList {
                                 return;
                             };
                             let queue = cx.global::<Models>().queue.read(cx);
-                            let queue_data =
-                                queue.data.read().expect("could not read queue");
+                            let queue_data = queue.data.read().expect("could not read queue");
                             let all_indices = drag_data.all_indices();
                             all_indices
                                 .into_iter()
-                                .filter_map(|i| {
-                                    queue_data.get(i).and_then(|item| item.get_db_id())
-                                })
+                                .filter_map(|i| queue_data.get(i).and_then(|item| item.get_db_id()))
                                 .collect()
                         } else {
                             drag_data.track_id.into_iter().collect()
@@ -368,8 +365,7 @@ impl Render for PlaylistList {
                         }
 
                         let pool = cx.global::<Pool>().0.clone();
-                        let playlist_tracker =
-                            cx.global::<Models>().playlist_tracker.clone();
+                        let playlist_tracker = cx.global::<Models>().playlist_tracker.clone();
 
                         cx.spawn(async move |_, cx| {
                             let task = crate::RUNTIME.spawn(async move {
@@ -410,8 +406,7 @@ impl Render for PlaylistList {
                         }
 
                         let pool = cx.global::<Pool>().0.clone();
-                        let playlist_tracker =
-                            cx.global::<Models>().playlist_tracker.clone();
+                        let playlist_tracker = cx.global::<Models>().playlist_tracker.clone();
 
                         cx.spawn(async move |_, cx| {
                             let task = crate::RUNTIME.spawn(async move {
@@ -426,9 +421,7 @@ impl Render for PlaylistList {
                                     return;
                                 }
                                 Err(err) => {
-                                    error!(
-                                        "add album tracks to playlist task panicked: {err:?}"
-                                    );
+                                    error!("add album tracks to playlist task panicked: {err:?}");
                                     return;
                                 }
                             }

--- a/src/ui/library/sidebar/playlists.rs
+++ b/src/ui/library/sidebar/playlists.rs
@@ -10,19 +10,21 @@ use tracing::error;
 
 use crate::{
     library::{
-        db::LibraryAccess,
+        db::{self, LibraryAccess},
         playlist::export_playlist,
         types::{Playlist, PlaylistType},
     },
     playback::interface::PlaybackInterface,
     settings::SettingsGlobal,
     ui::{
+        app::Pool,
         components::{
             button::{ButtonIntent, button},
             context::context,
             drag_drop::{
-                DragData, DragDropItemState, DragDropListConfig, DragDropListManager, DragPreview,
-                DropIndicator, check_drag_cancelled, handle_drag_move, handle_drop,
+                AlbumDragData, DragData, DragDropItemState, DragDropListConfig, DragDropListManager,
+                DragPreview, DropIndicator, TrackDragData, check_drag_cancelled, handle_drag_move,
+                handle_drop,
             },
             icons::{CROSS, FILE_EXPORT, PENCIL, PLAY, PLAYLIST, PLUS, SHUFFLE, STAR},
             menu::{menu, menu_item, menu_separator},
@@ -332,7 +334,112 @@ impl Render for PlaylistList {
                         move |_, _, _, cx| DragPreview::new(cx, drag_label.clone()),
                     )
                     .drag_over::<DragData>(|style, _, _, _| style.bg(rgba(0x88888822)))
-                });
+                })
+                .drag_over::<TrackDragData>(|style, _, _, _| style.bg(rgba(0x88888822)))
+                .drag_over::<AlbumDragData>(|style, _, _, _| style.bg(rgba(0x88888822)))
+                .on_drop(cx.listener(
+                    move |_: &mut PlaylistList, drag_data: &TrackDragData, _, cx| {
+                        let is_from_queue = drag_data
+                            .source_list_id
+                            .as_ref()
+                            .map(|id| *id == "queue".into())
+                            .unwrap_or(false);
+
+                        let track_ids: Vec<i64> = if is_from_queue {
+                            let Some(_source_index) = drag_data.source_index else {
+                                return;
+                            };
+                            let queue = cx.global::<Models>().queue.read(cx);
+                            let queue_data =
+                                queue.data.read().expect("could not read queue");
+                            let all_indices = drag_data.all_indices();
+                            all_indices
+                                .into_iter()
+                                .filter_map(|i| {
+                                    queue_data.get(i).and_then(|item| item.get_db_id())
+                                })
+                                .collect()
+                        } else {
+                            drag_data.track_id.into_iter().collect()
+                        };
+
+                        if track_ids.is_empty() {
+                            return;
+                        }
+
+                        let pool = cx.global::<Pool>().0.clone();
+                        let playlist_tracker =
+                            cx.global::<Models>().playlist_tracker.clone();
+
+                        cx.spawn(async move |_, cx| {
+                            let task = crate::RUNTIME.spawn(async move {
+                                db::add_tracks_to_playlist_if_missing(&pool, pl_id, &track_ids)
+                                    .await
+                            });
+
+                            match task.await {
+                                Ok(Ok(())) => {}
+                                Ok(Err(err)) => {
+                                    error!("could not add tracks to playlist: {err:?}");
+                                    return;
+                                }
+                                Err(err) => {
+                                    error!("add tracks to playlist task panicked: {err:?}");
+                                    return;
+                                }
+                            }
+
+                            playlist_tracker.update(cx, |_, cx| {
+                                cx.emit(PlaylistEvent::PlaylistUpdated(pl_id));
+                            });
+                        })
+                        .detach();
+                    },
+                ))
+                .on_drop(cx.listener(
+                    move |_: &mut PlaylistList, drag_data: &AlbumDragData, _, cx| {
+                        let track_ids: Vec<i64> =
+                            if let Ok(tracks) = cx.list_tracks_in_album(drag_data.album_id) {
+                                tracks.iter().map(|t| t.id).collect()
+                            } else {
+                                Vec::new()
+                            };
+
+                        if track_ids.is_empty() {
+                            return;
+                        }
+
+                        let pool = cx.global::<Pool>().0.clone();
+                        let playlist_tracker =
+                            cx.global::<Models>().playlist_tracker.clone();
+
+                        cx.spawn(async move |_, cx| {
+                            let task = crate::RUNTIME.spawn(async move {
+                                db::add_tracks_to_playlist_if_missing(&pool, pl_id, &track_ids)
+                                    .await
+                            });
+
+                            match task.await {
+                                Ok(Ok(())) => {}
+                                Ok(Err(err)) => {
+                                    error!("could not add album tracks to playlist: {err:?}");
+                                    return;
+                                }
+                                Err(err) => {
+                                    error!(
+                                        "add album tracks to playlist task panicked: {err:?}"
+                                    );
+                                    return;
+                                }
+                            }
+
+                            playlist_tracker.update(cx, |_, cx| {
+                                cx.emit(PlaylistEvent::PlaylistUpdated(pl_id));
+                            });
+                        })
+                        .detach();
+                    },
+                ));
 
             let rename_open = self.rename_popover_playlist == Some(pl_id);
             let weak_self = weak_entity.clone();

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -8,11 +8,10 @@ use crate::{
         components::{
             context::context,
             drag_drop::{
-                AlbumDragData, DragData, DragDropItemState, DragDropListConfig,
+                AlbumDragData, DragDropItemState, DragDropListConfig,
                 DragDropListManager, DragPreview, DropIndicator, TrackDragData,
-                calculate_drop_target, check_drag_cancelled, continue_edge_scroll,
-                get_edge_scroll_direction, handle_drag_move, handle_drop_multi,
-                perform_edge_scroll,
+                check_drag_cancelled, continue_edge_scroll,
+                handle_external_drag_move, handle_track_drag_move, handle_track_drop_multi,
             },
             icons::{CROSS, DISC, PLAYLIST_ADD, STAR, STAR_FILLED, TRASH, USERS, icon},
             managed_image::{ManagedImageKey, managed_image},
@@ -354,24 +353,38 @@ impl Render for QueueItem {
                             },
                         )
                         .when(is_available, |div| {
-                            let drag_data = if is_selected {
+                            let path_for_drag = self
+                                .item
+                                .as_ref()
+                                .map(|i| i.get_path().to_path_buf())
+                                .unwrap_or_default();
+                            let mut drag_data = if let Some(tid) = self.track_id {
+                                TrackDragData::from_track(
+                                    tid,
+                                    album_id,
+                                    path_for_drag,
+                                    track_name.clone(),
+                                )
+                            } else {
+                                TrackDragData::new(path_for_drag, track_name.clone())
+                            }
+                            .with_reorder_info(QUEUE_LIST_ID, idx);
+
+                            if is_selected {
                                 let all = selection_for_drag.read(cx).indices();
                                 let primary = all
                                     .iter()
                                     .position(|&i| i == idx)
                                     .expect("is_selected implies idx is in selection");
-                                DragData::new(idx, QUEUE_LIST_ID).with_additional_indices({
-                                    let mut others: Vec<usize> = all;
-                                    others.remove(primary);
-                                    others
-                                })
-                            } else {
-                                DragData::new(idx, QUEUE_LIST_ID)
-                            };
+                                let mut others: Vec<usize> = all;
+                                others.remove(primary);
+                                drag_data = drag_data.with_additional_indices(others);
+                            }
+
                             div.on_drag(drag_data, move |_, _, _, cx| {
                                 DragPreview::new(cx, track_name.clone())
                             })
-                            .drag_over::<DragData>(
+                            .drag_over::<TrackDragData>(
                                 move |style, _, _, _| style.bg(gpui::rgba(0x88888822)),
                             )
                         })
@@ -829,8 +842,11 @@ impl Render for Queue {
 
                         cx.notify();
                     }))
-                    .on_drag_move::<DragData>(cx.listener(
-                        move |this: &mut Queue, event: &DragMoveEvent<DragData>, window, cx| {
+                    .on_drag_move::<TrackDragData>(cx.listener(
+                        move |this: &mut Queue,
+                              event: &DragMoveEvent<TrackDragData>,
+                              window,
+                              cx| {
                             let scroll_handle: ScrollableHandle = this.scroll_handle.clone().into();
 
                             let reduced_motion = cx
@@ -839,7 +855,7 @@ impl Render for Queue {
                                 .read(cx)
                                 .interface
                                 .reduced_motion;
-                            let scrolled = handle_drag_move(
+                            let scrolled = handle_track_drag_move(
                                 this.drag_drop_manager.clone(),
                                 scroll_handle,
                                 event,
@@ -871,124 +887,30 @@ impl Render for Queue {
                             cx.notify();
                         },
                     ))
-                    .on_drag_move::<TrackDragData>(cx.listener(
-                        move |this: &mut Queue,
-                              event: &DragMoveEvent<TrackDragData>,
-                              window,
-                              cx| {
-                            let scroll_handle: ScrollableHandle = this.scroll_handle.clone().into();
-                            let config = this.drag_drop_manager.read(cx).config.clone();
-                            let mouse_pos = event.event.position;
-                            let container_bounds = event.bounds;
-
-                            this.drag_drop_manager.update(cx, |m, _| {
-                                m.state.is_dragging = true;
-                                m.state.set_mouse_y(mouse_pos.y);
-                                m.container_bounds = Some(container_bounds);
-                            });
-
-                            let direction = get_edge_scroll_direction(
-                                mouse_pos.y,
-                                container_bounds,
-                                &config.scroll_config,
-                            );
-                            let reduced_motion = cx
-                                .global::<SettingsGlobal>()
-                                .model
-                                .read(cx)
-                                .interface
-                                .reduced_motion;
-                            let scrolled = if reduced_motion {
-                                false
-                            } else {
-                                perform_edge_scroll(
-                                    &scroll_handle,
-                                    direction,
-                                    &config.scroll_config,
-                                )
-                            };
-
-                            if scrolled {
-                                let entity = cx.entity().downgrade();
-                                let manager = this.drag_drop_manager.clone();
-                                let scroll_handle: ScrollableHandle =
-                                    this.scroll_handle.clone().into();
-
-                                window.on_next_frame(move |window, cx| {
-                                    if let Some(entity) = entity.upgrade() {
-                                        entity.update(cx, |_, cx| {
-                                            Self::schedule_edge_scroll(
-                                                manager,
-                                                scroll_handle,
-                                                window,
-                                                cx,
-                                            );
-                                        });
-                                    }
-                                });
-                            }
-
-                            if container_bounds.contains(&mouse_pos) {
-                                let scroll_offset_y = scroll_handle.offset().y;
-                                let drop_target = calculate_drop_target(
-                                    mouse_pos,
-                                    container_bounds,
-                                    scroll_offset_y,
-                                    config.item_height,
-                                    queue_len,
-                                );
-
-                                this.drag_drop_manager.update(cx, |m, _| {
-                                    if let Some((item_index, drop_position)) = drop_target {
-                                        m.state.update_drop_target(item_index, drop_position);
-                                    } else {
-                                        m.state.clear_drop_target();
-                                    }
-                                });
-                            } else {
-                                this.drag_drop_manager
-                                    .update(cx, |m, _| m.state.clear_drop_target());
-                            }
-
-                            cx.notify();
-                        },
-                    ))
                     .on_drag_move::<AlbumDragData>(cx.listener(
                         move |this: &mut Queue,
                               event: &DragMoveEvent<AlbumDragData>,
                               window,
                               cx| {
                             let scroll_handle: ScrollableHandle = this.scroll_handle.clone().into();
-                            let config = this.drag_drop_manager.read(cx).config.clone();
                             let mouse_pos = event.event.position;
                             let container_bounds = event.bounds;
 
-                            this.drag_drop_manager.update(cx, |m, _| {
-                                m.state.is_dragging = true;
-                                m.state.set_mouse_y(mouse_pos.y);
-                                m.container_bounds = Some(container_bounds);
-                            });
-
-                            let direction = get_edge_scroll_direction(
-                                mouse_pos.y,
-                                container_bounds,
-                                &config.scroll_config,
-                            );
                             let reduced_motion = cx
                                 .global::<SettingsGlobal>()
                                 .model
                                 .read(cx)
                                 .interface
                                 .reduced_motion;
-                            let scrolled = if reduced_motion {
-                                false
-                            } else {
-                                perform_edge_scroll(
-                                    &scroll_handle,
-                                    direction,
-                                    &config.scroll_config,
-                                )
-                            };
+                            let scrolled = handle_external_drag_move(
+                                this.drag_drop_manager.clone(),
+                                scroll_handle,
+                                mouse_pos,
+                                container_bounds,
+                                queue_len,
+                                cx,
+                                reduced_motion,
+                            );
 
                             if scrolled {
                                 let entity = cx.entity().downgrade();
@@ -1010,84 +932,65 @@ impl Render for Queue {
                                 });
                             }
 
-                            if container_bounds.contains(&mouse_pos) {
-                                let scroll_offset_y = scroll_handle.offset().y;
-                                let drop_target = calculate_drop_target(
-                                    mouse_pos,
-                                    container_bounds,
-                                    scroll_offset_y,
-                                    config.item_height,
-                                    queue_len,
-                                );
-
-                                this.drag_drop_manager.update(cx, |m, _| {
-                                    if let Some((item_index, drop_position)) = drop_target {
-                                        m.state.update_drop_target(item_index, drop_position);
-                                    } else {
-                                        m.state.clear_drop_target();
-                                    }
-                                });
-                            } else {
-                                this.drag_drop_manager
-                                    .update(cx, |m, _| m.state.clear_drop_target());
-                            }
-
                             cx.notify();
                         },
                     ))
-                    .on_drop(
-                        cx.listener(move |this: &mut Queue, drag_data: &DragData, _, cx| {
-                            handle_drop_multi(
-                                this.drag_drop_manager.clone(),
-                                drag_data,
-                                cx,
-                                |drag_data, to, cx| {
-                                    if drag_data.additional_indices.is_empty() {
-                                        cx.global::<PlaybackInterface>()
-                                            .move_item(drag_data.source_index, to);
-                                    } else {
-                                        let corrected_to = to.saturating_sub(
-                                            drag_data
-                                                .additional_indices
-                                                .iter()
-                                                .filter(|&&idx| idx < to)
-                                                .count(),
-                                        );
-                                        let indices = drag_data.all_indices();
-                                        cx.global::<PlaybackInterface>()
-                                            .move_items(indices, corrected_to);
-                                    }
-                                },
-                            );
-                            cx.notify();
-                        }),
-                    )
-                    // track drops
                     .on_drop(cx.listener(
                         move |this: &mut Queue, drag_data: &TrackDragData, _, cx| {
                             use crate::ui::components::drag_drop::DropPosition;
 
-                            let queue_item = QueueItemData::new(
-                                cx,
-                                drag_data.path.clone(),
-                                drag_data.track_id,
-                                drag_data.album_id,
-                            );
+                            let is_internal = drag_data
+                                .source_list_id
+                                .as_ref()
+                                .map(|id| *id == QUEUE_LIST_ID.into())
+                                .unwrap_or(false);
 
-                            let drop_target = this.drag_drop_manager.read(cx).state.drop_target;
-
-                            if let Some((target_index, position)) = drop_target {
-                                let insert_pos = match position {
-                                    DropPosition::Before => target_index,
-                                    DropPosition::After => target_index + 1,
-                                };
-                                cx.global::<PlaybackInterface>()
-                                    .insert_at(queue_item, insert_pos);
+                            if is_internal {
+                                handle_track_drop_multi(
+                                    this.drag_drop_manager.clone(),
+                                    drag_data,
+                                    cx,
+                                    |drag_data, to, cx| {
+                                        if drag_data.additional_indices.is_empty() {
+                                            cx.global::<PlaybackInterface>()
+                                                .move_item(drag_data.source_index.unwrap(), to);
+                                        } else {
+                                            let corrected_to = to.saturating_sub(
+                                                drag_data
+                                                    .additional_indices
+                                                    .iter()
+                                                    .filter(|&&idx| idx < to)
+                                                    .count(),
+                                            );
+                                            let indices = drag_data.all_indices();
+                                            cx.global::<PlaybackInterface>()
+                                                .move_items(indices, corrected_to);
+                                        }
+                                    },
+                                );
                             } else {
-                                cx.global::<PlaybackInterface>().queue(queue_item);
-                            }
+                                let queue_item = QueueItemData::new(
+                                    cx,
+                                    drag_data.path.clone(),
+                                    drag_data.track_id,
+                                    drag_data.album_id,
+                                );
 
-                            this.drag_drop_manager.update(cx, |m, _| m.state.end_drag());
+                                let drop_target = this.drag_drop_manager.read(cx).state.drop_target;
+
+                                if let Some((target_index, position)) = drop_target {
+                                    let insert_pos = match position {
+                                        DropPosition::Before => target_index,
+                                        DropPosition::After => target_index + 1,
+                                    };
+                                    cx.global::<PlaybackInterface>()
+                                        .insert_at(queue_item, insert_pos);
+                                } else {
+                                    cx.global::<PlaybackInterface>().queue(queue_item);
+                                }
+
+                                this.drag_drop_manager.update(cx, |m, _| m.state.end_drag());
+                            }
                             cx.notify();
                         },
                     ))

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -8,10 +8,10 @@ use crate::{
         components::{
             context::context,
             drag_drop::{
-                AlbumDragData, DragDropItemState, DragDropListConfig,
-                DragDropListManager, DragPreview, DropIndicator, TrackDragData,
-                check_drag_cancelled, continue_edge_scroll,
-                handle_external_drag_move, handle_track_drag_move, handle_track_drop_multi,
+                AlbumDragData, DragDropItemState, DragDropListConfig, DragDropListManager,
+                DragPreview, DropIndicator, TrackDragData, check_drag_cancelled,
+                continue_edge_scroll, handle_external_drag_move, handle_track_drag_move,
+                handle_track_drop_multi,
             },
             icons::{CROSS, DISC, PLAYLIST_ADD, STAR, STAR_FILLED, TRASH, USERS, icon},
             managed_image::{ManagedImageKey, managed_image},

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -265,19 +265,19 @@
   },
   "CANCEL": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:585",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:692",
     "plural": false,
     "description": null
   },
   "CLEAR_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:795",
+    "definedIn": "src/ui/queue.rs:808",
     "plural": false,
     "description": null
   },
   "CLOSE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:806",
+    "definedIn": "src/ui/queue.rs:819",
     "plural": false,
     "description": null
   },
@@ -367,7 +367,7 @@
   },
   "CREATE": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:594",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:701",
     "plural": false,
     "description": null
   },
@@ -379,7 +379,7 @@
   },
   "DELETE_PLAYLIST": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:439",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:546",
     "plural": false,
     "description": null
   },
@@ -409,13 +409,13 @@
   },
   "EXPORT_PLAYLIST": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:427",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:534",
     "plural": false,
     "description": null
   },
   "EXPORT_PLAYLIST_TO_M3U": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:244",
+    "definedIn": "src/ui/library/playlist_view.rs:245",
     "plural": false,
     "description": null
   },
@@ -433,13 +433,13 @@
   },
   "GO_TO_ALBUM": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:557",
+    "definedIn": "src/ui/queue.rs:570",
     "plural": false,
     "description": null
   },
   "GO_TO_ARTIST": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:574",
+    "definedIn": "src/ui/queue.rs:587",
     "plural": false,
     "description": null
   },
@@ -631,7 +631,7 @@
   },
   "LIKED_SONGS": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:270",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:272",
     "plural": false,
     "description": null
   },
@@ -661,7 +661,7 @@
   },
   "NEW_PLAYLIST": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:543",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:650",
     "plural": false,
     "description": null
   },
@@ -763,7 +763,7 @@
   },
   "PLAYLIST_TRACK_COUNT": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:308",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:310",
     "plural": true,
     "description": null
   },
@@ -787,7 +787,7 @@
   },
   "QUEUE_TITLE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:787",
+    "definedIn": "src/ui/queue.rs:800",
     "plural": false,
     "description": null
   },
@@ -829,7 +829,7 @@
   },
   "REMOVE_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:636",
+    "definedIn": "src/ui/queue.rs:649",
     "plural": false,
     "description": null
   },
@@ -841,19 +841,19 @@
   },
   "REMOVE_N_FROM_QUEUE": {
     "context": "queue.rs",
-    "definedIn": "src/ui/queue.rs:539",
+    "definedIn": "src/ui/queue.rs:552",
     "plural": true,
     "description": null
   },
   "RENAME": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:517",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:624",
     "plural": false,
     "description": null
   },
   "RENAME_PLAYLIST": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:400",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:507",
     "plural": false,
     "description": null
   },
@@ -1285,13 +1285,13 @@
   },
   "SORT_ALBUM": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:69",
+    "definedIn": "src/ui/library/playlist_view.rs:71",
     "plural": false,
     "description": null
   },
   "SORT_ARTIST": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:66",
+    "definedIn": "src/ui/library/playlist_view.rs:68",
     "plural": false,
     "description": null
   },
@@ -1303,7 +1303,7 @@
   },
   "SORT_CUSTOM": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:61",
+    "definedIn": "src/ui/library/playlist_view.rs:63",
     "plural": false,
     "description": null
   },
@@ -1315,7 +1315,7 @@
   },
   "SORT_DURATION": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:72",
+    "definedIn": "src/ui/library/playlist_view.rs:74",
     "plural": false,
     "description": null
   },

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -265,7 +265,7 @@
   },
   "CANCEL": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:692",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:685",
     "plural": false,
     "description": null
   },
@@ -367,7 +367,7 @@
   },
   "CREATE": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:701",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:694",
     "plural": false,
     "description": null
   },
@@ -379,7 +379,7 @@
   },
   "DELETE_PLAYLIST": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:546",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:539",
     "plural": false,
     "description": null
   },
@@ -409,7 +409,7 @@
   },
   "EXPORT_PLAYLIST": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:534",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:527",
     "plural": false,
     "description": null
   },
@@ -661,7 +661,7 @@
   },
   "NEW_PLAYLIST": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:650",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:643",
     "plural": false,
     "description": null
   },
@@ -847,13 +847,13 @@
   },
   "RENAME": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:624",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:617",
     "plural": false,
     "description": null
   },
   "RENAME_PLAYLIST": {
     "context": "playlists.rs",
-    "definedIn": "src/ui/library/sidebar/playlists.rs:507",
+    "definedIn": "src/ui/library/sidebar/playlists.rs:500",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
Allows a user to drag and drop tracks and albums from the queue and other pages into the playlists on the sidebar and in the playlist view.

## Changes
Some queue D&D refactoring was done to make this work.

## Testing
Dragged a bunch of items around various ways, IIRC every way possible. They all work.

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [x] Documentation added/updated where needed
- [x] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - Some code was generated with Kimi K2.6.