### PR TITLE
refactor: begin keybind refactor for editing

### DIFF
--- a/assets/keybinds.json
+++ b/assets/keybinds.json
@@ -1,0 +1,69 @@
+{
+  "bindings": [
+    { "key": "cmd-q", "action": "hummingbird::Quit", "platform": "macos" },
+    { "key": "cmd-right", "action": "player::Next", "platform": "macos" },
+    { "key": "cmd-left", "action": "player::Previous", "platform": "macos" },
+    { "key": "cmd-h", "action": "hummingbird::HideSelf", "platform": "macos" },
+    { "key": "cmd-alt-h", "action": "hummingbird::HideOthers", "platform": "macos" },
+
+    { "key": "ctrl-q", "action": "hummingbird::Quit", "platform": "!macos" },
+    { "key": "ctrl-w", "action": "hummingbird::CloseWindow", "platform": "!macos" },
+
+    { "key": "secondary-right", "action": "player::Next" },
+    { "key": "secondary-left", "action": "player::Previous" },
+    { "key": "secondary-p", "action": "hummingbird::Search" },
+    { "key": "secondary-f", "action": "hummingbird::Search" },
+    { "key": "secondary-shift-p", "action": "hummingbird::OpenPalette" },
+    { "key": "secondary-,", "action": "hummingbird::Settings" },
+    { "key": "escape", "action": "hummingbird::CloseWindow", "context": "SettingsWindow && !TextInput" },
+    { "key": "secondary-z", "action": "queue::Undo", "context": "!TextInput" },
+    { "key": "alt-shift-s", "action": "scan::ForceScan" },
+    { "key": "alt-s", "action": "scan::Scan" },
+    { "key": "space", "action": "player::PlayPause" },
+    { "key": "ctrl-shift-space", "action": "player::StopAfterCurrent", "context": "!TextInput" },
+
+    { "key": "backspace", "action": "library::NavigateBack", "context": "Library" },
+    { "key": "alt-left", "action": "library::NavigateBack", "context": "Library" },
+    { "key": "alt-right", "action": "library::NavigateForward", "context": "Library" },
+    { "key": "escape", "action": "library::EscapeBack", "context": "Library" },
+
+    { "key": "secondary-s", "action": "playlist::Export" },
+
+    { "key": "escape", "action": "modal::CloseModal" },
+    { "key": "escape", "action": "popover::ClosePopover" },
+    { "key": "escape", "action": "context::CloseContextMenu" },
+
+    { "key": "escape", "action": "dropdown::Close", "context": "Dropdown" },
+    { "key": "down", "action": "dropdown::SelectNext", "context": "Dropdown" },
+    { "key": "up", "action": "dropdown::SelectPrev", "context": "Dropdown" },
+    { "key": "tab", "action": "dropdown::SelectNext", "context": "Dropdown" },
+    { "key": "shift-tab", "action": "dropdown::SelectPrev", "context": "Dropdown" },
+    { "key": "enter", "action": "dropdown::Confirm", "context": "Dropdown" },
+    { "key": "space", "action": "dropdown::Confirm", "context": "Dropdown" },
+    { "key": "home", "action": "dropdown::SelectFirst", "context": "Dropdown" },
+    { "key": "end", "action": "dropdown::SelectLast", "context": "Dropdown" },
+
+    { "key": "backspace", "action": "text_input::Backspace", "context": "TextInput" },
+    { "key": "delete", "action": "text_input::Delete", "context": "TextInput" },
+    { "key": "left", "action": "text_input::Left", "context": "TextInput" },
+    { "key": "right", "action": "text_input::Right", "context": "TextInput" },
+    { "key": "shift-left", "action": "text_input::SelectLeft", "context": "TextInput" },
+    { "key": "shift-right", "action": "text_input::SelectRight", "context": "TextInput" },
+    { "key": "home", "action": "text_input::Home", "context": "TextInput" },
+    { "key": "end", "action": "text_input::End", "context": "TextInput" },
+    { "key": "enter", "action": "text_input::Accept", "context": "TextInput" },
+    { "key": "down", "action": "text_input::Next", "context": "TextInput" },
+    { "key": "up", "action": "text_input::Previous", "context": "TextInput" },
+
+    { "key": "cmd-a", "action": "text_input::SelectAll", "platform": "macos", "context": "TextInput" },
+    { "key": "cmd-v", "action": "text_input::Paste", "platform": "macos", "context": "TextInput" },
+    { "key": "cmd-c", "action": "text_input::Copy", "platform": "macos", "context": "TextInput" },
+    { "key": "cmd-x", "action": "text_input::Cut", "platform": "macos", "context": "TextInput" },
+    { "key": "ctrl-cmd-space", "action": "text_input::ShowCharacterPalette", "platform": "macos", "context": "TextInput" },
+
+    { "key": "ctrl-a", "action": "text_input::SelectAll", "platform": "!macos", "context": "TextInput" },
+    { "key": "ctrl-v", "action": "text_input::Paste", "platform": "!macos", "context": "TextInput" },
+    { "key": "ctrl-c", "action": "text_input::Copy", "platform": "!macos", "context": "TextInput" },
+    { "key": "ctrl-x", "action": "text_input::Cut", "platform": "!macos", "context": "TextInput" }
+  ]
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -11,6 +11,7 @@ mod controls;
 pub mod data;
 mod global_actions;
 mod header;
+mod keymap;
 pub mod library;
 mod lyrics;
 pub mod models;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -36,8 +36,7 @@ use crate::{
         assets::HummingbirdAssetSource,
         caching::HummingbirdImageCache,
         command_palette::{CommandPalette, CommandPaletteHolder},
-        components::dropdown,
-        library::{self, missing_folder_dialog::MissingFolderDialog},
+        library::missing_folder_dialog::MissingFolderDialog,
         models::WindowInformation,
         settings::corrupt_settings_dialog::CorruptSettingsDialog,
     },
@@ -47,9 +46,7 @@ use super::{
     about::about_dialog,
     arguments::parse_args_and_prepare,
     components::{
-        context, input,
         modal::{self, ModalActive},
-        popover,
         window_chrome::window_chrome,
     },
     controls::Controls,
@@ -399,12 +396,7 @@ pub fn run() -> anyhow::Result<()> {
             initial_repeat,
         );
 
-        input::bind_actions(cx);
-        modal::bind_actions(cx);
-        library::bind_actions(cx);
-        dropdown::bind_actions(cx);
-        popover::bind_actions(cx);
-        context::bind_actions(cx);
+        super::keymap::load_default_keymap(cx);
 
         cx.set_global(modal::ModalActive(AtomicBool::new(false)));
 

--- a/src/ui/components/context.rs
+++ b/src/ui/components/context.rs
@@ -4,10 +4,6 @@ use crate::ui::theme::Theme;
 
 actions!(context, [CloseContextMenu]);
 
-pub fn bind_actions(cx: &mut App) {
-    cx.bind_keys([KeyBinding::new("escape", CloseContextMenu, None)]);
-}
-
 #[derive(IntoElement)]
 pub struct ContextMenu {
     pub(self) id: ElementId,

--- a/src/ui/components/dropdown.rs
+++ b/src/ui/components/dropdown.rs
@@ -2,9 +2,9 @@ use std::rc::Rc;
 
 use cntp_i18n::tr;
 use gpui::{
-    App, Corner, Div, ElementId, InteractiveElement, IntoElement, KeyBinding, ParentElement,
-    RenderOnce, SharedString, StatefulInteractiveElement, StyleRefinement, Styled, Window, actions,
-    anchored, deferred, div, prelude::FluentBuilder, px,
+    App, Corner, Div, ElementId, InteractiveElement, IntoElement, ParentElement, RenderOnce,
+    SharedString, StatefulInteractiveElement, StyleRefinement, Styled, Window, actions, anchored,
+    deferred, div, prelude::FluentBuilder, px,
 };
 use smallvec::SmallVec;
 
@@ -27,20 +27,6 @@ actions!(
         SelectLast
     ]
 );
-
-pub fn bind_actions(cx: &mut App) {
-    cx.bind_keys([
-        KeyBinding::new("escape", Close, None),
-        KeyBinding::new("down", SelectNext, None),
-        KeyBinding::new("up", SelectPrev, None),
-        KeyBinding::new("tab", SelectNext, None),
-        KeyBinding::new("shift-tab", SelectPrev, None),
-        KeyBinding::new("enter", Confirm, None),
-        KeyBinding::new("space", Confirm, None),
-        KeyBinding::new("home", SelectFirst, None),
-        KeyBinding::new("end", SelectLast, None),
-    ]);
-}
 
 #[derive(IntoElement)]
 pub struct Dropdown<T: Clone + PartialEq + 'static> {

--- a/src/ui/components/input.rs
+++ b/src/ui/components/input.rs
@@ -4,8 +4,8 @@ use std::ops::Range;
 
 use gpui::{
     App, Bounds, ClipboardItem, Context, CursorStyle, ElementId, ElementInputHandler, Entity,
-    EntityInputHandler, EventEmitter, FocusHandle, Focusable, GlobalElementId, KeyBinding,
-    LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point,
+    EntityInputHandler, EventEmitter, FocusHandle, Focusable, GlobalElementId, LayoutId,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point,
     ScrollHandle, ShapedLine, SharedString, Style, TextRun, UTF16Selection, UnderlineStyle, Window,
     actions, div, fill, hsla, point, prelude::*, px, relative, rgba, size,
 };
@@ -40,41 +40,6 @@ pub enum EnrichedInputAction {
     Next,
     Previous,
     Accept,
-}
-
-pub fn bind_actions(cx: &mut App) {
-    cx.bind_keys([
-        KeyBinding::new("backspace", Backspace, None),
-        KeyBinding::new("delete", Delete, None),
-        KeyBinding::new("left", Left, None),
-        KeyBinding::new("right", Right, None),
-        KeyBinding::new("shift-left", SelectLeft, None),
-        KeyBinding::new("shift-right", SelectRight, None),
-        KeyBinding::new("home", Home, None),
-        KeyBinding::new("end", End, None),
-        KeyBinding::new("enter", Accept, None),
-        KeyBinding::new("down", Next, None),
-        KeyBinding::new("up", Previous, None),
-    ]);
-
-    if cfg!(target_os = "macos") {
-        cx.bind_keys([
-            KeyBinding::new("cmd-a", SelectAll, None),
-            KeyBinding::new("cmd-v", Paste, None),
-            KeyBinding::new("cmd-c", Copy, None),
-            KeyBinding::new("cmd-x", Cut, None),
-            KeyBinding::new("ctrl-cmd-space", ShowCharacterPalette, None),
-        ]);
-    }
-
-    if !cfg!(target_os = "macos") {
-        cx.bind_keys([
-            KeyBinding::new("ctrl-a", SelectAll, None),
-            KeyBinding::new("ctrl-v", Paste, None),
-            KeyBinding::new("ctrl-c", Copy, None),
-            KeyBinding::new("ctrl-x", Cut, None),
-        ]);
-    }
 }
 
 type EnrichedInputHandler = Box<dyn Fn(EnrichedInputAction, &mut Window, &mut App)>;
@@ -728,140 +693,3 @@ impl Focusable for TextInput {
         self.focus_handle.clone()
     }
 }
-
-// struct InputExample {
-//     text_input: Entity<TextInput>,
-//     recent_keystrokes: Vec<Keystroke>,
-//     focus_handle: FocusHandle,
-// }
-
-// impl Focusable for InputExample {
-//     fn focus_handle(&self, _: &App) -> FocusHandle {
-//         self.focus_handle.clone()
-//     }
-// }
-
-// impl InputExample {
-//     fn on_reset_click(&mut self, _: &MouseUpEvent, _window: &mut Window, cx: &mut Context<Self>) {
-//         self.recent_keystrokes.clear();
-//         self.text_input
-//             .update(cx, |text_input, _cx| text_input.reset());
-//         cx.notify();
-//     }
-// }
-
-// impl Render for InputExample {
-//     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-//         div()
-//             .bg(rgb(0xaaaaaa))
-//             .track_focus(&self.focus_handle(cx))
-//             .flex()
-//             .flex_col()
-//             .size_full()
-//             .child(
-//                 div()
-//                     .bg(white())
-//                     .border_b_1()
-//                     .border_color(black())
-//                     .flex()
-//                     .flex_row()
-//                     .justify_between()
-//                     .child(format!("Keyboard {}", cx.keyboard_layout()))
-//                     .child(
-//                         div()
-//                             .border_1()
-//                             .border_color(black())
-//                             .px_2()
-//                             .bg(yellow())
-//                             .child("Reset")
-//                             .hover(|style| {
-//                                 style
-//                                     .bg(yellow().blend(opaque_grey(0.5, 0.5)))
-//                                     .cursor_pointer()
-//                             })
-//                             .on_mouse_up(MouseButton::Left, cx.listener(Self::on_reset_click)),
-//                     ),
-//             )
-//             .child(self.text_input.clone())
-//             .children(self.recent_keystrokes.iter().rev().map(|ks| {
-//                 format!(
-//                     "{:} {}",
-//                     ks.unparse(),
-//                     if let Some(key_char) = ks.key_char.as_ref() {
-//                         format!("-> {:?}", key_char)
-//                     } else {
-//                         "".to_owned()
-//                     }
-//                 )
-//             }))
-//     }
-// }
-
-// fn main() {
-//     Application::new().run(|cx: &mut App| {
-//         let bounds = Bounds::centered(None, size(px(300.0), px(300.0)), cx);
-//         cx.bind_keys([
-//             KeyBinding::new("backspace", Backspace, None),
-//             KeyBinding::new("delete", Delete, None),
-//             KeyBinding::new("left", Left, None),
-//             KeyBinding::new("right", Right, None),
-//             KeyBinding::new("shift-left", SelectLeft, None),
-//             KeyBinding::new("shift-right", SelectRight, None),
-//             KeyBinding::new("cmd-a", SelectAll, None),
-//             KeyBinding::new("cmd-v", Paste, None),
-//             KeyBinding::new("cmd-c", Copy, None),
-//             KeyBinding::new("cmd-x", Cut, None),
-//             KeyBinding::new("home", Home, None),
-//             KeyBinding::new("end", End, None),
-//             KeyBinding::new("ctrl-cmd-space", ShowCharacterPalette, None),
-//         ]);
-
-//         let window = cx
-//             .open_window(
-//                 WindowOptions {
-//                     window_bounds: Some(WindowBounds::Windowed(bounds)),
-//                     ..Default::default()
-//                 },
-//                 |_, cx| {
-//                     let text_input = cx.new(|cx| TextInput {
-//                         focus_handle: cx.focus_handle(),
-//                         content: "".into(),
-//                         placeholder: "Type here...".into(),
-//                         selected_range: 0..0,
-//                         selection_reversed: false,
-//                         marked_range: None,
-//                         last_layout: None,
-//                         last_bounds: None,
-//                         is_selecting: false,
-//                     });
-//                     cx.new(|cx| InputExample {
-//                         text_input,
-//                         recent_keystrokes: vec![],
-//                         focus_handle: cx.focus_handle(),
-//                     })
-//                 },
-//             )
-//             .unwrap();
-//         let view = window.update(cx, |_, _, cx| cx.entity()).unwrap();
-//         cx.observe_keystrokes(move |ev, _, cx| {
-//             view.update(cx, |view, cx| {
-//                 view.recent_keystrokes.push(ev.keystroke.clone());
-//                 cx.notify();
-//             })
-//         })
-//         .detach();
-//         cx.on_keyboard_layout_change({
-//             move |cx| {
-//                 window.update(cx, |_, _, cx| cx.notify()).ok();
-//             }
-//         })
-//         .detach();
-
-//         window
-//             .update(cx, |view, window, cx| {
-//                 window.focus(&view.text_input.focus_handle(cx));
-//                 cx.activate(true);
-//             })
-//             .unwrap();
-//     });
-// }

--- a/src/ui/components/modal.rs
+++ b/src/ui/components/modal.rs
@@ -36,10 +36,6 @@ impl Modal {
 
 actions!(modal, [CloseModal]);
 
-pub fn bind_actions(cx: &mut App) {
-    cx.bind_keys([KeyBinding::new("escape", CloseModal, None)]);
-}
-
 impl ParentElement for Modal {
     fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
         self.div.extend(elements);

--- a/src/ui/components/popover.rs
+++ b/src/ui/components/popover.rs
@@ -1,9 +1,8 @@
 use std::rc::Rc;
 
 use gpui::{
-    AnyElement, App, Div, InteractiveElement, IntoElement, KeyBinding, ParentElement, Pixels,
-    RenderOnce, StatefulInteractiveElement, StyleRefinement, Styled, Window, deferred, div, px,
-    relative,
+    AnyElement, App, Div, InteractiveElement, IntoElement, ParentElement, Pixels, RenderOnce,
+    StatefulInteractiveElement, StyleRefinement, Styled, Window, deferred, div, px, relative,
 };
 use gpui::{actions, prelude::FluentBuilder};
 
@@ -12,10 +11,6 @@ use crate::ui::theme::Theme;
 pub type OnDismissHandler = dyn Fn(&mut Window, &mut App);
 
 actions!(popover, [ClosePopover]);
-
-pub fn bind_actions(cx: &mut App) {
-    cx.bind_keys([KeyBinding::new("escape", ClosePopover, None)]);
-}
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/src/ui/global_actions.rs
+++ b/src/ui/global_actions.rs
@@ -1,5 +1,5 @@
 use cntp_i18n::tr;
-use gpui::{App, AppContext, KeyBinding, MenuItem, actions};
+use gpui::{App, AppContext, MenuItem, actions};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -57,38 +57,6 @@ pub fn register_actions(cx: &mut App) {
 
     debug!("actions: {:?}", cx.all_action_names());
     debug!("action available: {:?}", cx.is_action_available(&Quit));
-    if cfg!(target_os = "macos") {
-        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
-        cx.bind_keys([KeyBinding::new("cmd-right", Next, None)]);
-        cx.bind_keys([KeyBinding::new("cmd-left", Previous, None)]);
-        cx.bind_keys([KeyBinding::new("cmd-h", HideSelf, None)]);
-        cx.bind_keys([KeyBinding::new("cmd-alt-h", HideOthers, None)]);
-    } else {
-        cx.bind_keys([KeyBinding::new("ctrl-q", Quit, None)]);
-        cx.bind_keys([KeyBinding::new("ctrl-w", CloseWindow, None)]);
-    }
-
-    cx.bind_keys([KeyBinding::new("secondary-right", Next, None)]);
-    cx.bind_keys([KeyBinding::new("secondary-left", Previous, None)]);
-    cx.bind_keys([KeyBinding::new("secondary-p", Search, None)]);
-    cx.bind_keys([KeyBinding::new("secondary-f", Search, None)]);
-    cx.bind_keys([KeyBinding::new("secondary-shift-p", OpenPalette, None)]);
-    cx.bind_keys([KeyBinding::new("secondary-,", Settings, None)]);
-    cx.bind_keys([KeyBinding::new(
-        "escape",
-        CloseWindow,
-        Some("SettingsWindow && !TextInput"),
-    )]);
-    cx.bind_keys([KeyBinding::new("secondary-z", Undo, Some("!TextInput"))]);
-
-    cx.bind_keys([KeyBinding::new("alt-shift-s", ForceScan, None)]);
-    cx.bind_keys([KeyBinding::new("alt-s", Scan, None)]);
-    cx.bind_keys([KeyBinding::new("space", PlayPause, None)]);
-    cx.bind_keys([KeyBinding::new(
-        "ctrl-shift-space",
-        StopAfterCurrent,
-        Some("!TextInput"),
-    )]);
 
     let mut app_menu = MenuBuilder::new(tr!("APP_NAME"))
         .add_item(menu_item(

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -1,0 +1,94 @@
+use gpui::{App, KeyBinding, KeyBindingContextPredicate};
+use serde::Deserialize;
+use std::rc::Rc;
+
+const DEFAULT_KEYBINDS: &str = include_str!("../../assets/keybinds.json");
+
+#[derive(Deserialize)]
+struct KeymapFile {
+    bindings: Vec<KeymapEntry>,
+}
+
+#[derive(Deserialize)]
+struct KeymapEntry {
+    key: String,
+    action: String,
+    #[serde(default)]
+    context: Option<String>,
+    #[serde(default)]
+    platform: Option<String>,
+}
+
+fn parse_default_keybinds() -> KeymapFile {
+    serde_json::from_str(DEFAULT_KEYBINDS).expect("default keybinds JSON must parse")
+}
+
+pub fn load_default_keymap(cx: &mut App) {
+    let file = parse_default_keybinds();
+
+    let bindings: Vec<KeyBinding> = file
+        .bindings
+        .into_iter()
+        .filter(|e| platform_matches(e.platform.as_deref()))
+        .map(|e| {
+            let action = cx
+                .build_action(&e.action, None)
+                .unwrap_or_else(|err| panic!("unknown action {}: {err}", e.action));
+            let context_predicate = e.context.as_deref().map(|ctx| {
+                Rc::new(
+                    KeyBindingContextPredicate::parse(ctx)
+                        .unwrap_or_else(|err| panic!("invalid context {:?}: {err}", ctx)),
+                )
+            });
+            KeyBinding::load(
+                &e.key,
+                action,
+                context_predicate,
+                false,
+                None,
+                &gpui::DummyKeyboardMapper,
+            )
+            .unwrap_or_else(|err| panic!("invalid key {:?}: {err}", e.key))
+        })
+        .collect();
+
+    cx.bind_keys(bindings);
+}
+
+fn platform_matches(spec: Option<&str>) -> bool {
+    match spec {
+        None => true,
+        Some("macos") => cfg!(target_os = "macos"),
+        Some("linux") => cfg!(target_os = "linux"),
+        Some("windows") => cfg!(target_os = "windows"),
+        Some("!macos") => !cfg!(target_os = "macos"),
+        Some("!linux") => !cfg!(target_os = "linux"),
+        Some("!windows") => !cfg!(target_os = "windows"),
+        Some(other) => panic!("unknown platform spec: {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_keybinds_json_parses() {
+        let file = parse_default_keybinds();
+        assert!(!file.bindings.is_empty());
+    }
+
+    #[test]
+    fn platform_filter_covers_all_entries() {
+        let file = parse_default_keybinds();
+        let filtered: Vec<_> = file
+            .bindings
+            .iter()
+            .filter(|e| platform_matches(e.platform.as_deref()))
+            .collect();
+        assert!(
+            !filtered.is_empty(),
+            "no keybindings match the current platform"
+        );
+    }
+}

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -16,7 +16,36 @@ struct KeymapEntry {
     #[serde(default)]
     context: Option<String>,
     #[serde(default)]
-    platform: Option<String>,
+    platform: Option<Platform>,
+}
+
+#[derive(Deserialize, Clone, Copy)]
+enum Platform {
+    #[serde(rename = "macos")]
+    Macos,
+    #[serde(rename = "linux")]
+    Linux,
+    #[serde(rename = "windows")]
+    Windows,
+    #[serde(rename = "!macos")]
+    NotMacos,
+    #[serde(rename = "!linux")]
+    NotLinux,
+    #[serde(rename = "!windows")]
+    NotWindows,
+}
+
+impl Platform {
+    fn matches(self) -> bool {
+        match self {
+            Self::Macos => cfg!(target_os = "macos"),
+            Self::Linux => cfg!(target_os = "linux"),
+            Self::Windows => cfg!(target_os = "windows"),
+            Self::NotMacos => !cfg!(target_os = "macos"),
+            Self::NotLinux => !cfg!(target_os = "linux"),
+            Self::NotWindows => !cfg!(target_os = "windows"),
+        }
+    }
 }
 
 fn parse_default_keybinds() -> KeymapFile {
@@ -29,7 +58,7 @@ pub fn load_default_keymap(cx: &mut App) {
     let bindings: Vec<KeyBinding> = file
         .bindings
         .into_iter()
-        .filter(|e| platform_matches(e.platform.as_deref()))
+        .filter(|e| e.platform.is_none_or(Platform::matches))
         .map(|e| {
             let action = cx
                 .build_action(&e.action, None)
@@ -55,19 +84,6 @@ pub fn load_default_keymap(cx: &mut App) {
     cx.bind_keys(bindings);
 }
 
-fn platform_matches(spec: Option<&str>) -> bool {
-    match spec {
-        None => true,
-        Some("macos") => cfg!(target_os = "macos"),
-        Some("linux") => cfg!(target_os = "linux"),
-        Some("windows") => cfg!(target_os = "windows"),
-        Some("!macos") => !cfg!(target_os = "macos"),
-        Some("!linux") => !cfg!(target_os = "linux"),
-        Some("!windows") => !cfg!(target_os = "windows"),
-        Some(other) => panic!("unknown platform spec: {other}"),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,7 +100,7 @@ mod tests {
         let filtered: Vec<_> = file
             .bindings
             .iter()
-            .filter(|e| platform_matches(e.platform.as_deref()))
+            .filter(|e| e.platform.is_none_or(Platform::matches))
             .collect();
         assert!(
             !filtered.is_empty(),

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -51,16 +51,6 @@ mod update_playlist;
 
 actions!(library, [NavigateBack, NavigateForward, EscapeBack]);
 
-pub fn bind_actions(cx: &mut App) {
-    playlist_view::bind_actions(cx);
-    cx.bind_keys([
-        KeyBinding::new("backspace", NavigateBack, Some("Library")),
-        KeyBinding::new("alt-left", NavigateBack, Some("Library")),
-        KeyBinding::new("alt-right", NavigateForward, Some("Library")),
-        KeyBinding::new("escape", EscapeBack, Some("Library")),
-    ]);
-}
-
 /// The navigation history + a cursor noting what the current message is.
 #[derive(Debug)]
 pub struct NavigationHistory {

--- a/src/ui/library/playlist_view.rs
+++ b/src/ui/library/playlist_view.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use cntp_i18n::tr;
 use gpui::{
     App, AppContext, Context, DragMoveEvent, Entity, FocusHandle, FontWeight, InteractiveElement,
-    IntoElement, KeyBinding, ParentElement, Render, SharedString, StatefulInteractiveElement,
-    Styled, UniformListScrollHandle, Window, actions, div, prelude::FluentBuilder, px, rems, rgba,
+    IntoElement, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled,
+    UniformListScrollHandle, Window, actions, div, prelude::FluentBuilder, px, rems, rgba,
     uniform_list,
 };
 use rustc_hash::FxHashMap;
@@ -53,10 +53,6 @@ actions!(playlist, [Export, Import]);
 
 // height + border
 const PLAYLIST_ITEM_HEIGHT: f32 = 40.0;
-
-pub fn bind_actions(cx: &mut App) {
-    cx.bind_keys([KeyBinding::new("secondary-s", Export, None)]);
-}
 
 fn sort_method_label(method: PlaylistTrackSortMethod) -> SharedString {
     match method {

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -1,7 +1,7 @@
 {
   "ABOUT": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:95",
+    "definedIn": "src/ui/global_actions.rs:63",
     "plural": false,
     "description": null
   },
@@ -145,7 +145,7 @@
   },
   "ACTION_IMPORT_PLAYLIST": {
     "context": "library.rs",
-    "definedIn": "src/ui/library.rs:491",
+    "definedIn": "src/ui/library.rs:481",
     "plural": false,
     "description": null
   },
@@ -361,7 +361,7 @@
   },
   "COMMAND_PALETTE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:206",
+    "definedIn": "src/ui/global_actions.rs:174",
     "plural": false,
     "description": null
   },
@@ -385,19 +385,19 @@
   },
   "DISCORD": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:164",
+    "definedIn": "src/ui/global_actions.rs:132",
     "plural": false,
     "description": null
   },
   "DROPDOWN_PLACEHOLDER": {
     "context": "dropdown.rs",
-    "definedIn": "src/ui/components/dropdown.rs:95",
+    "definedIn": "src/ui/components/dropdown.rs:81",
     "plural": false,
     "description": null
   },
   "EDIT": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:194",
+    "definedIn": "src/ui/global_actions.rs:162",
     "plural": false,
     "description": null
   },
@@ -415,19 +415,19 @@
   },
   "EXPORT_PLAYLIST_TO_M3U": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:245",
+    "definedIn": "src/ui/library/playlist_view.rs:241",
     "plural": false,
     "description": null
   },
   "FILE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:189",
+    "definedIn": "src/ui/global_actions.rs:157",
     "plural": false,
     "description": null
   },
   "GITHUB_ISSUES": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:159",
+    "definedIn": "src/ui/global_actions.rs:127",
     "plural": false,
     "description": null
   },
@@ -451,19 +451,19 @@
   },
   "HELP": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:141",
+    "definedIn": "src/ui/global_actions.rs:109",
     "plural": false,
     "description": null
   },
   "HIDE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:120",
+    "definedIn": "src/ui/global_actions.rs:88",
     "plural": false,
     "description": null
   },
   "HIDE_OTHERS": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:125",
+    "definedIn": "src/ui/global_actions.rs:93",
     "plural": false,
     "description": null
   },
@@ -607,19 +607,19 @@
   },
   "LIBRARY_FORCE_RESCAN": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:230",
+    "definedIn": "src/ui/global_actions.rs:198",
     "plural": false,
     "description": null
   },
   "LIBRARY_SCAN": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:225",
+    "definedIn": "src/ui/global_actions.rs:193",
     "plural": false,
     "description": null
   },
   "LIBRARY_SHUFFLE_ALL": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:219",
+    "definedIn": "src/ui/global_actions.rs:187",
     "plural": false,
     "description": null
   },
@@ -685,7 +685,7 @@
   },
   "PATREON": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:181",
+    "definedIn": "src/ui/global_actions.rs:149",
     "plural": false,
     "description": null
   },
@@ -793,7 +793,7 @@
   },
   "QUIT": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:136",
+    "definedIn": "src/ui/global_actions.rs:104",
     "plural": false,
     "description": null
   },
@@ -1075,7 +1075,7 @@
   },
   "SEARCH": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:211",
+    "definedIn": "src/ui/global_actions.rs:179",
     "plural": false,
     "description": null
   },
@@ -1243,7 +1243,7 @@
   },
   "SHOW_ALL": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:130",
+    "definedIn": "src/ui/global_actions.rs:98",
     "plural": false,
     "description": null
   },
@@ -1285,13 +1285,13 @@
   },
   "SORT_ALBUM": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:71",
+    "definedIn": "src/ui/library/playlist_view.rs:67",
     "plural": false,
     "description": null
   },
   "SORT_ARTIST": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:68",
+    "definedIn": "src/ui/library/playlist_view.rs:64",
     "plural": false,
     "description": null
   },
@@ -1303,7 +1303,7 @@
   },
   "SORT_CUSTOM": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:63",
+    "definedIn": "src/ui/library/playlist_view.rs:59",
     "plural": false,
     "description": null
   },
@@ -1315,7 +1315,7 @@
   },
   "SORT_DURATION": {
     "context": "playlist_view.rs",
-    "definedIn": "src/ui/library/playlist_view.rs:74",
+    "definedIn": "src/ui/library/playlist_view.rs:70",
     "plural": false,
     "description": null
   },
@@ -1429,7 +1429,7 @@
   },
   "UNDO_QUEUE": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:195",
+    "definedIn": "src/ui/global_actions.rs:163",
     "plural": false,
     "description": null
   },
@@ -1489,13 +1489,13 @@
   },
   "VIEW": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:201",
+    "definedIn": "src/ui/global_actions.rs:169",
     "plural": false,
     "description": "The View menu. Must *exactly* match the text required by macOS."
   },
   "WINDOW": {
     "context": "global_actions.rs",
-    "definedIn": "src/ui/global_actions.rs:242",
+    "definedIn": "src/ui/global_actions.rs:210",
     "plural": false,
     "description": "The Window menu. Must *exactly* match the text required by macOS."
   }


### PR DESCRIPTION
## Summary
Extracts all keybinds out into `assets/keybinds.json` in preparation for a keymap editor.

## Changes
<!-- What specific changes were made? -->

## Testing
<!-- How did you test these changes? -->

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
