### PR TITLE
refactor: command palette actions

### DIFF
--- a/assets/commands.json
+++ b/assets/commands.json
@@ -1,0 +1,89 @@
+{
+  "commands": [
+    {
+      "id": "hummingbird::quit",
+      "category": "Hummingbird",
+      "name_key": "ACTION_QUIT",
+      "action": "hummingbird::Quit"
+    },
+    {
+      "id": "hummingbird::about",
+      "category": "Hummingbird",
+      "name_key": "ACTION_ABOUT",
+      "action": "hummingbird::About"
+    },
+    {
+      "id": "hummingbird::search",
+      "category": "Hummingbird",
+      "name_key": "ACTION_SEARCH",
+      "action": "hummingbird::Search"
+    },
+    {
+      "id": "hummingbird::settings",
+      "category": "Hummingbird",
+      "name_key": "ACTION_SETTINGS",
+      "action": "hummingbird::Settings"
+    },
+    {
+      "id": "hummingbird::check_for_updates",
+      "category": "Hummingbird",
+      "name_key": "ACTION_CHECK_FOR_UPDATES",
+      "action": "hummingbird::CheckForUpdates",
+      "feature": "update"
+    },
+    {
+      "id": "hummingbird::open_log",
+      "category": "Hummingbird",
+      "name_key": "ACTION_OPEN_LOG",
+      "action": "hummingbird::OpenLog"
+    },
+    {
+      "id": "hummingbird::copy_troubleshooting_info",
+      "category": "Hummingbird",
+      "name_key": "ACTION_COPY_TROUBLESHOOTING_INFO",
+      "action": "hummingbird::CopyTroubleshootingInfo"
+    },
+    {
+      "id": "player::playpause",
+      "category": "Playback",
+      "name_key": "ACTION_PLAYPAUSE",
+      "action": "player::PlayPause"
+    },
+    {
+      "id": "player::next",
+      "category": "Playback",
+      "name_key": "ACTION_NEXT",
+      "action": "player::Next"
+    },
+    {
+      "id": "player::previous",
+      "category": "Playback",
+      "name_key": "ACTION_PREVIOUS",
+      "action": "player::Previous"
+    },
+    {
+      "id": "shuffle::all",
+      "category": "Playback",
+      "name_key": "ACTION_SHUFFLE_ALL",
+      "action": "player::ShuffleAll"
+    },
+    {
+      "id": "player::stop_after_current",
+      "category": "Playback",
+      "name_key": "ACTION_STOP_AFTER_CURRENT",
+      "action": "player::StopAfterCurrent"
+    },
+    {
+      "id": "scan::forcescan",
+      "category": "Scan",
+      "name_key": "ACTION_FORCESCAN",
+      "action": "scan::ForceScan"
+    },
+    {
+      "id": "undo::queue",
+      "category": "Queue",
+      "name_key": "ACTION_UNDO_QUEUE",
+      "action": "queue::Undo"
+    }
+  ]
+}

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -1,33 +1,41 @@
-use std::sync::{Arc, atomic::Ordering};
+use std::sync::{Arc, Mutex, atomic::Ordering};
 
-use cntp_i18n::{I18nString, tr};
+use cntp_i18n::{I18nString, tr, tr_noop};
 use gpui::{
     Action, App, AppContext, Context, Entity, EventEmitter, FocusHandle, Global, IntoElement,
     ParentElement, Render, SharedString, Styled, Window, actions, div, px,
 };
 use nucleo::Utf32String;
 use rustc_hash::FxHashMap;
+use serde::Deserialize;
 use std::hash::Hash;
 use tracing::error;
 
-#[cfg(feature = "update")]
-use crate::ui::global_actions::CheckForUpdates;
-use crate::ui::{components::modal::ModalActive, global_actions::Undo};
-use crate::ui::{
-    components::{
-        modal::modal,
-        palette::{FinderItemLeft, Palette, PaletteItem},
-    },
-    global_actions::{
-        About, ForceScan, Next, PlayPause, Previous, Quit, Search, Settings, ShuffleAll,
-        StopAfterCurrent,
-    },
-    troubleshooting::{CopyTroubleshootingInfo, OpenLog},
-};
+use crate::ui::components::modal::{ModalActive, modal};
+use crate::ui::components::palette::{FinderItemLeft, Palette, PaletteItem};
 
 actions!(hummingbird, [OpenPalette]);
 
-#[derive(Clone, Copy)]
+tr_noop!("ACTION_QUIT", "Quit");
+tr_noop!("ACTION_ABOUT", "About");
+tr_noop!("ACTION_SEARCH", "Search");
+tr_noop!("ACTION_SETTINGS", "Settings");
+tr_noop!("ACTION_CHECK_FOR_UPDATES", "Check for Updates");
+tr_noop!("ACTION_OPEN_LOG", "Open Log");
+tr_noop!(
+    "ACTION_COPY_TROUBLESHOOTING_INFO",
+    "Copy Troubleshooting Info"
+);
+tr_noop!("ACTION_PLAYPAUSE", "Pause/Resume Current Track");
+tr_noop!("ACTION_NEXT", "Next Track");
+tr_noop!("ACTION_PREVIOUS", "Previous Track");
+tr_noop!("ACTION_SHUFFLE_ALL", "Shuffle All Tracks");
+tr_noop!("ACTION_STOP_AFTER_CURRENT", "Stop After Current");
+tr_noop!("ACTION_FORCESCAN", "Rescan Entire Library");
+tr_noop!("ACTION_UNDO_QUEUE", "Undo");
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 pub enum CommandCategory {
     Hummingbird,
     Playback,
@@ -58,11 +66,51 @@ impl CommandCategory {
     }
 }
 
+enum CommandAction {
+    Value(Box<dyn Action + Sync>),
+    Named {
+        name: &'static str,
+        cached: Mutex<Option<Box<dyn Action>>>,
+    },
+}
+
+impl CommandAction {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Value(action) => action.name(),
+            Self::Named { name, .. } => name,
+        }
+    }
+
+    fn with_action<R>(
+        &self,
+        cx: &mut App,
+        f: impl FnOnce(&mut App, &dyn Action) -> R,
+    ) -> Option<R> {
+        match self {
+            Self::Value(action) => Some(f(cx, &**action)),
+            Self::Named { name, cached } => {
+                let mut guard = cached.lock().unwrap();
+                if guard.is_none() {
+                    match cx.build_action(name, None) {
+                        Ok(action) => *guard = Some(action),
+                        Err(err) => {
+                            error!("Failed to build command palette action {name}: {err}");
+                            return None;
+                        }
+                    }
+                }
+                guard.as_deref().map(|action| f(cx, action))
+            }
+        }
+    }
+}
+
 pub struct CommandSpec {
     id: (&'static str, i64),
     category: Option<CommandCategory>,
     name: SharedString,
-    action: Box<dyn Action + Sync>,
+    action: CommandAction,
     focus_handle: Option<FocusHandle>,
 }
 
@@ -77,7 +125,26 @@ impl CommandSpec {
             id,
             category,
             name: name.into(),
-            action: Box::new(action),
+            action: CommandAction::Value(Box::new(action)),
+            focus_handle: None,
+        }
+    }
+
+    fn named(
+        id: (&'static str, i64),
+        category: Option<CommandCategory>,
+        name: impl Into<SharedString>,
+        action_name: &'static str,
+        prebuilt: Box<dyn Action>,
+    ) -> Self {
+        Self {
+            id,
+            category,
+            name: name.into(),
+            action: CommandAction::Named {
+                name: action_name,
+                cached: Mutex::new(Some(prebuilt)),
+            },
             focus_handle: None,
         }
     }
@@ -102,13 +169,13 @@ impl CommandSpec {
 pub struct Command {
     category: Option<CommandCategory>,
     name: SharedString,
-    action: Box<dyn Action + Sync>,
+    action: CommandAction,
     focus_handle: Option<FocusHandle>,
 }
 
 impl PartialEq for Command {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.action.partial_eq(&(*other.action))
+        self.name == other.name && self.action.name() == other.action.name()
     }
 }
 
@@ -117,6 +184,16 @@ impl Hash for Command {
         self.name.hash(state);
         self.action.name().hash(state);
     }
+}
+
+fn binding_label(binding: &gpui::KeyBinding) -> SharedString {
+    binding
+        .keystrokes()
+        .iter()
+        .map(|key| key.to_string())
+        .collect::<Vec<String>>()
+        .join(" + ")
+        .into()
 }
 
 impl PaletteItem for Command {
@@ -134,19 +211,13 @@ impl PaletteItem for Command {
     }
 
     fn right_content(&self, cx: &mut gpui::App) -> Option<SharedString> {
-        cx.key_bindings()
-            .borrow()
-            .bindings_for_action(&(*self.action))
-            .last()
-            .map(|binding| {
-                binding
-                    .keystrokes()
-                    .iter()
-                    .map(|key| key.to_string())
-                    .collect::<Vec<String>>()
-                    .join(" + ")
-                    .into()
-            })
+        self.action.with_action(cx, |cx, action| {
+            cx.key_bindings()
+                .borrow()
+                .bindings_for_action(action)
+                .last()
+                .map(binding_label)
+        })?
     }
 }
 
@@ -170,97 +241,53 @@ fn sorted_commands(items: &FxHashMap<(&'static str, i64), Arc<Command>>) -> Vec<
     commands
 }
 
-fn builtin_commands() -> Vec<CommandSpec> {
-    vec![
-        CommandSpec::new(
-            ("hummingbird::quit", 0),
-            Some(CommandCategory::Hummingbird),
-            tr!("ACTION_QUIT", "Quit"),
-            Quit,
-        ),
-        CommandSpec::new(
-            ("hummingbird::about", 0),
-            Some(CommandCategory::Hummingbird),
-            tr!("ACTION_ABOUT", "About"),
-            About,
-        ),
-        CommandSpec::new(
-            ("hummingbird::search", 0),
-            Some(CommandCategory::Hummingbird),
-            tr!("ACTION_SEARCH", "Search"),
-            Search,
-        ),
-        CommandSpec::new(
-            ("hummingbird::settings", 0),
-            Some(CommandCategory::Hummingbird),
-            tr!("ACTION_SETTINGS", "Settings"),
-            Settings,
-        ),
+const DEFAULT_COMMANDS: &str = include_str!("../../assets/commands.json");
+
+#[derive(Deserialize)]
+struct CommandFile {
+    commands: Vec<CommandEntry>,
+}
+
+#[derive(Deserialize)]
+struct CommandEntry {
+    id: String,
+    category: CommandCategory,
+    name_key: String,
+    action: String,
+    #[serde(default)]
+    feature: Option<String>,
+}
+
+fn is_feature_enabled(feature: &str) -> bool {
+    // right now, `update` is the only feature with a command entry
+    match feature {
         #[cfg(feature = "update")]
-        CommandSpec::new(
-            ("hummingbird::check_for_updates", 0),
-            Some(CommandCategory::Hummingbird),
-            tr!("ACTION_CHECK_FOR_UPDATES", "Check for Updates"),
-            CheckForUpdates,
-        ),
-        CommandSpec::new(
-            ("hummingbird::open_log", 0),
-            Some(CommandCategory::Hummingbird),
-            tr!("ACTION_OPEN_LOG", "Open Log"),
-            OpenLog,
-        ),
-        CommandSpec::new(
-            ("hummingbird::copy_troubleshooting_info", 0),
-            Some(CommandCategory::Hummingbird),
-            tr!(
-                "ACTION_COPY_TROUBLESHOOTING_INFO",
-                "Copy Troubleshooting Info"
-            ),
-            CopyTroubleshootingInfo,
-        ),
-        CommandSpec::new(
-            ("player::playpause", 0),
-            Some(CommandCategory::Playback),
-            tr!("ACTION_PLAYPAUSE", "Pause/Resume Current Track"),
-            PlayPause,
-        ),
-        CommandSpec::new(
-            ("player::next", 0),
-            Some(CommandCategory::Playback),
-            tr!("ACTION_NEXT", "Next Track"),
-            Next,
-        ),
-        CommandSpec::new(
-            ("player::previous", 0),
-            Some(CommandCategory::Playback),
-            tr!("ACTION_PREVIOUS", "Previous Track"),
-            Previous,
-        ),
-        CommandSpec::new(
-            ("shuffle::all", 0),
-            Some(CommandCategory::Playback),
-            tr!("ACTION_SHUFFLE_ALL", "Shuffle All Tracks"),
-            ShuffleAll,
-        ),
-        CommandSpec::new(
-            ("player::stop_after_current", 0),
-            Some(CommandCategory::Playback),
-            tr!("ACTION_STOP_AFTER_CURRENT", "Stop After Current"),
-            StopAfterCurrent,
-        ),
-        CommandSpec::new(
-            ("scan::forcescan", 0),
-            Some(CommandCategory::Scan),
-            tr!("ACTION_FORCESCAN", "Rescan Entire Library"),
-            ForceScan,
-        ),
-        CommandSpec::new(
-            ("undo::queue", 0),
-            Some(CommandCategory::Queue),
-            tr!("ACTION_UNDO_QUEUE", "Undo"),
-            Undo,
-        ),
-    ]
+        "update" => true,
+
+        _ => false,
+    }
+}
+
+fn load_builtin_commands(cx: &mut App) -> Vec<CommandSpec> {
+    let file: CommandFile =
+        serde_json::from_str(DEFAULT_COMMANDS).expect("default commands JSON must parse");
+
+    file.commands
+        .into_iter()
+        .filter(|e| e.feature.as_deref().is_none_or(is_feature_enabled))
+        .map(|e| {
+            let built = cx
+                .build_action(&e.action, None)
+                .unwrap_or_else(|err| panic!("unknown action {}: {err}", e.action));
+
+            let name =
+                cntp_i18n::i18n_manager!().lookup(&e.name_key, &[], env!("CARGO_PKG_NAME"), None);
+
+            let id: &'static str = Box::leak(e.id.into_boxed_str());
+            let action: &'static str = Box::leak(e.action.into_boxed_str());
+            CommandSpec::named((id, 0), Some(e.category), name, action, built)
+        })
+        .collect()
 }
 
 type MatcherFunc = Box<dyn Fn(&Arc<Command>, &mut App) -> Utf32String + 'static>;
@@ -292,7 +319,8 @@ impl CommandPalette {
                         error!("Failed to focus window, action may not trigger: {}", err);
                     }
 
-                    cx.dispatch_action(&(*item.action));
+                    item.action
+                        .with_action(cx, |cx, action| cx.dispatch_action(action));
 
                     show_clone.update(cx, |show, cx| {
                         *show = false;
@@ -321,7 +349,7 @@ impl CommandPalette {
             })
             .detach();
 
-            for spec in builtin_commands() {
+            for spec in load_builtin_commands(cx) {
                 let (id, command) = spec.build();
                 items.insert(id, command);
             }

--- a/translations/meta.json
+++ b/translations/meta.json
@@ -91,55 +91,55 @@
   },
   "ACTION_ABOUT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:184",
+    "definedIn": "src/ui/command_palette.rs:20",
     "plural": false,
     "description": null
   },
   "ACTION_CHECK_FOR_UPDATES": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:203",
+    "definedIn": "src/ui/command_palette.rs:23",
     "plural": false,
     "description": null
   },
   "ACTION_COPY_TROUBLESHOOTING_INFO": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:216",
+    "definedIn": "src/ui/command_palette.rs:26",
     "plural": false,
     "description": null
   },
   "ACTION_FORCESCAN": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:254",
+    "definedIn": "src/ui/command_palette.rs:34",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_HUMMINGBIRD": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:42",
+    "definedIn": "src/ui/command_palette.rs:50",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_PLAYBACK": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:43",
+    "definedIn": "src/ui/command_palette.rs:51",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_PLAYLIST": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:45",
+    "definedIn": "src/ui/command_palette.rs:53",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_QUEUE": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:44",
+    "definedIn": "src/ui/command_palette.rs:52",
     "plural": false,
     "description": null
   },
   "ACTION_GROUP_SCAN": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:46",
+    "definedIn": "src/ui/command_palette.rs:54",
     "plural": false,
     "description": null
   },
@@ -151,61 +151,61 @@
   },
   "ACTION_NEXT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:230",
+    "definedIn": "src/ui/command_palette.rs:30",
     "plural": false,
     "description": null
   },
   "ACTION_OPEN_LOG": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:209",
+    "definedIn": "src/ui/command_palette.rs:24",
     "plural": false,
     "description": null
   },
   "ACTION_PLAYPAUSE": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:224",
+    "definedIn": "src/ui/command_palette.rs:29",
     "plural": false,
     "description": null
   },
   "ACTION_PREVIOUS": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:236",
+    "definedIn": "src/ui/command_palette.rs:31",
     "plural": false,
     "description": null
   },
   "ACTION_QUIT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:178",
+    "definedIn": "src/ui/command_palette.rs:19",
     "plural": false,
     "description": null
   },
   "ACTION_SEARCH": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:190",
+    "definedIn": "src/ui/command_palette.rs:21",
     "plural": false,
     "description": null
   },
   "ACTION_SETTINGS": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:196",
+    "definedIn": "src/ui/command_palette.rs:22",
     "plural": false,
     "description": null
   },
   "ACTION_SHUFFLE_ALL": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:242",
+    "definedIn": "src/ui/command_palette.rs:32",
     "plural": false,
     "description": null
   },
   "ACTION_STOP_AFTER_CURRENT": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:248",
+    "definedIn": "src/ui/command_palette.rs:33",
     "plural": false,
     "description": null
   },
   "ACTION_UNDO_QUEUE": {
     "context": "command_palette.rs",
-    "definedIn": "src/ui/command_palette.rs:260",
+    "definedIn": "src/ui/command_palette.rs:35",
     "plural": false,
     "description": null
   },


### PR DESCRIPTION
## Summary
Moves command palette actions out of `command_palette.rs` and mostly into `assets/commands.json`. Translation keys still need to have a `tr_noop!` invocation so cntp_i18n is happy.

## Changes
<!-- What specific changes were made? -->

## Testing
<!-- How did you test these changes? -->

## Checklist
- [ ] No new warnings or clippy lints introduced - if so, explain why
- [ ] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
