### PR TITLE
feat: add pipewire backend

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev desktop-file-utils libfontconfig1-dev
+          sudo apt-get install -y libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev desktop-file-utils libfontconfig1-dev libpipewire-0.3-dev libspa-0.2-dev
       - name: Update Rust
         run: rustup update
       - name: Install clippy

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev desktop-file-utils libfontconfig1-dev minisign
+          sudo apt-get install -y libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev desktop-file-utils libfontconfig1-dev minisign libpipewire-0.3-dev libspa-0.2-dev
       - name: Update rust
         run: rustup update
       - name: Install cntp build tools

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev desktop-file-utils libfontconfig1-dev minisign
+          sudo apt-get install -y libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev desktop-file-utils libfontconfig1-dev minisign libpipewire-0.3-dev libspa-0.2-dev
       - name: Update rust
         run: rustup update
       - name: Install cntp build tools

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev desktop-file-utils libfontconfig1-dev
+          sudo apt-get install -y libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev desktop-file-utils libfontconfig1-dev libpipewire-0.3-dev libspa-0.2-dev
       - name: Update Rust
         run: rustup update
       - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +712,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "annotate-snippets",
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +1006,16 @@ dependencies = [
  "byteorder",
  "fnv",
  "uuid 1.23.0",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1434,12 +1473,27 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
 name = "core-foundation"
@@ -1647,6 +1701,7 @@ dependencies = [
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-foundation",
+ "pipewire",
  "web-sys",
  "windows 0.61.3",
 ]
@@ -1904,7 +1959,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2921,7 +2976,7 @@ dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "async-task",
- "bindgen",
+ "bindgen 0.71.1",
  "bitflags 2.11.0",
  "block",
  "cbindgen",
@@ -4530,6 +4585,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "libspa"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cc",
+ "convert_case 0.8.0",
+ "cookie-factory",
+ "libc",
+ "libspa-sys",
+ "nix 0.30.1",
+ "nom 8.0.0",
+ "system-deps",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901049455d2eb6decf9058235d745237952f4804bc584c5fcb41412e6adcc6e0"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "system-deps",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4746,7 +4829,7 @@ version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed#6143af13a3a4eb4ea84f545af34ea4d3cf54207b"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.71.1",
  "core-foundation 0.10.0",
  "core-video",
  "ctor",
@@ -4973,6 +5056,18 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -5832,6 +5927,34 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.4.1",
  "futures-io",
+]
+
+[[package]]
+name = "pipewire"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "nix 0.30.1",
+ "once_cell",
+ "pipewire-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb028afee0d6ca17020b090e3b8fa2d7de23305aef975c7e5192a5050246ea36"
+dependencies = [
+ "bindgen 0.72.1",
+ "libspa-sys",
+ "system-deps",
 ]
 
 [[package]]
@@ -7969,6 +8092,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
+ "version-compare",
+]
+
+[[package]]
 name = "taffy"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8003,6 +8139,12 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"
@@ -8280,6 +8422,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -8857,6 +9014,12 @@ dependencies = [
  "derive_builder",
  "rustversion",
 ]
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4", features = ["derive"] }
 cntp_i18n = { version = "0.1", features = ["gpui"] }
 compact_str = { version = "0.9", features = ["sqlx-sqlite"] }
 console-subscriber = { version = "0.5", optional = true }
-cpal = { git = "https://github.com/RustAudio/cpal" }
+cpal = { git = "https://github.com/RustAudio/cpal", features = ["pipewire"] }
 dateparser = "0.3"
 derive_more = { version = "2", features = ["debug"] }
 directories = "6"

--- a/docs/building.md
+++ b/docs/building.md
@@ -14,12 +14,12 @@ On Linux, you'll need the development headers for several packages. The followin
 
 - **Fedora/CentOS/EL**
   ```sh
-  sudo dnf install libxkbcommon-devel libxkbcommon-x11-devel alsa-lib-devel make gcc perl-core pcre-devel zlib-devel libX11-devel wayland-devel pulseaudio-libs-devel openssl-devel libxcb-devel pulseaudio-libs-devel fontconfig-devel
+  sudo dnf install libxkbcommon-devel libxkbcommon-x11-devel alsa-lib-devel make gcc perl-core pcre-devel zlib-devel libX11-devel wayland-devel pulseaudio-libs-devel openssl-devel libxcb-devel pulseaudio-libs-devel fontconfig-devel pipewire-devel
   ```
 - **Ubuntu**
   ```sh
   sudo apt update
-  sudo apt install libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev build-essential libfontconfig1-dev
+  sudo apt install libasound2-dev pkg-config libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libpulse-dev build-essential libfontconfig1-dev libpipewire-0.3-dev libspa-0.2-dev
   ```
   
 ### NixOS / Nix / Nix (darwin)

--- a/src/devices/builtin/cpal.rs
+++ b/src/devices/builtin/cpal.rs
@@ -158,12 +158,17 @@ impl CpalDevice {
         let config =
             cpal_config_from_info(&format).map_err(|_| OpenError::InvalidConfigProvider)?;
         let ChannelSpec::Count(channels) = format.channels;
+        // 200ms at the configured sample rate, scaled by the number of channels
+        let desired_buffer_size = ((200 * config.sample_rate as usize) / 1000) * channels as usize;
         let buffer_size = match format.buffer_size {
-            // take what ever the minimum buffer size is, but always at least 2048 samples
-            BufferSize::Range(min, max) => min.max(2048).min(max) as usize,
+            // take what ever the minimum buffer size is, unless it's less than the
+            // desired_buffer_size, in which case use the desired_buffer_size
+            BufferSize::Range(min, max) => {
+                (min as usize).max(desired_buffer_size).min(max as usize)
+            }
             BufferSize::Fixed(size) => size as usize,
-            // if the buffer size is unknown, use a default of 200ms at the configured sample rate
-            BufferSize::Unknown => ((200 * config.sample_rate as usize) / 1000) * channels as usize,
+            // if the buffer size is unknown, just use the desired_buffer_size
+            BufferSize::Unknown => desired_buffer_size,
         };
         let target_gain = Arc::new(AtomicF64::new(1.0));
         let (stream, prod) =

--- a/src/devices/builtin/cpal.rs
+++ b/src/devices/builtin/cpal.rs
@@ -158,8 +158,13 @@ impl CpalDevice {
         let config =
             cpal_config_from_info(&format).map_err(|_| OpenError::InvalidConfigProvider)?;
         let ChannelSpec::Count(channels) = format.channels;
-        // 200ms at the configured sample rate, scaled by the number of channels
-        let desired_buffer_size = ((200 * config.sample_rate as usize) / 1000) * channels as usize;
+        // 100ms at the configured sample rate, scaled by the number of channels
+        let desired_buffer_size =
+            ((100 * config.sample_rate as usize) / 1000) * 2 * channels as usize;
+        info!(
+            "Desired buffer size: {desired_buffer_size}, format allows: {:?}",
+            format.buffer_size
+        );
         let buffer_size = match format.buffer_size {
             // take what ever the minimum buffer size is, unless it's less than the
             // desired_buffer_size, in which case use the desired_buffer_size
@@ -170,6 +175,7 @@ impl CpalDevice {
             // if the buffer size is unknown, just use the desired_buffer_size
             BufferSize::Unknown => desired_buffer_size,
         };
+        info!("Requesting buffer size: {buffer_size}");
         let target_gain = Arc::new(AtomicF64::new(1.0));
         let (stream, prod) =
             create_stream_internal::<T>(&self.device, config, buffer_size, target_gain.clone())?;

--- a/src/devices/builtin/cpal.rs
+++ b/src/devices/builtin/cpal.rs
@@ -20,6 +20,7 @@ use rb::{Producer, RB, RbConsumer, RbProducer, SpscRb};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use tracing::info;
 
 /// Delay between requesting a fade-out and pausing the stream. Must exceed
 /// the gain ramp length (15 ms) plus a few callback periods to ensure the
@@ -41,6 +42,9 @@ impl Default for CpalProvider {
 impl DeviceProvider for CpalProvider {
     fn initialize(&mut self) -> Result<(), InitializationError> {
         self.host = cpal::default_host();
+
+        info!("Using cpal host {}", self.host.id().name());
+
         Ok(())
     }
 
@@ -154,7 +158,13 @@ impl CpalDevice {
         let config =
             cpal_config_from_info(&format).map_err(|_| OpenError::InvalidConfigProvider)?;
         let ChannelSpec::Count(channels) = format.channels;
-        let buffer_size = ((200 * config.sample_rate as usize) / 1000) * channels as usize;
+        let buffer_size = match format.buffer_size {
+            // take what ever the minimum buffer size is, but always at least 2048 samples
+            BufferSize::Range(min, max) => min.max(2048).min(max) as usize,
+            BufferSize::Fixed(size) => size as usize,
+            // if the buffer size is unknown, use a default of 200ms at the configured sample rate
+            BufferSize::Unknown => ((200 * config.sample_rate as usize) / 1000) * channels as usize,
+        };
         let target_gain = Arc::new(AtomicF64::new(1.0));
         let (stream, prod) =
             create_stream_internal::<T>(&self.device, config, buffer_size, target_gain.clone())?;

--- a/src/playback/thread/device_controller.rs
+++ b/src/playback/thread/device_controller.rs
@@ -1,6 +1,6 @@
 use std::env::consts::OS;
 
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     devices::{
@@ -108,7 +108,6 @@ impl DeviceController {
     /// Initialize the device provider based on the environment or platform defaults.
     pub fn initialize_provider(&mut self) {
         let default_device_provider = match OS {
-            "linux" => "cpal", // TODO: use pulseaudio
             "windows" => "win_audiograph",
             _ => "cpal",
         };
@@ -123,7 +122,7 @@ impl DeviceController {
     pub fn initialize_provider_by_name(&mut self, provider_name: &str) {
         match provider_name {
             "pulse" => {
-                warn!("pulseaudio support was removed");
+                warn!("pulseaudio supported by cpal");
                 warn!("Falling back to CPAL");
                 self.device_provider = Some(Box::new(CpalProvider::default()));
             }
@@ -150,6 +149,11 @@ impl DeviceController {
                 warn!("Falling back to CPAL");
                 self.device_provider = Some(Box::new(CpalProvider::default()));
             }
+        }
+
+        if let Err(e) = self.device_provider.as_mut().unwrap().initialize() {
+            error!("Failed to initialize device provider: {}", e);
+            warn!("Audio may not play");
         }
     }
 


### PR DESCRIPTION
## Summary
Enables the `pipewire` CPAL feature and adds some logging to detail which backend is being used. This also includes changes that make device initialization and buffer size selection more reliable.

This has the added effect of actually correctly retrieving the sample format on my computer, which improves the sound quality a small bit because it's no longer doubly resampled.

## Changes

## Testing

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
