### PR TITLE
fix(metadata): prefer non-id3v1 tags

### DIFF
--- a/src/media/builtin/lofty.rs
+++ b/src/media/builtin/lofty.rs
@@ -3,7 +3,7 @@ use std::{ffi::OsStr, fs::File};
 use lofty::file::{AudioFile, TaggedFileExt};
 use lofty::picture::PictureType;
 use lofty::prelude::ItemKey;
-use lofty::tag::{ItemValue, Tag, TagItem};
+use lofty::tag::{ItemValue, Tag, TagItem, TagType};
 
 use crate::media::{
     errors::{
@@ -113,7 +113,16 @@ fn read_tags_from_file(mut file: File) -> Result<TagsFromFile, OpenError> {
     let mut metadata = Metadata::default();
     let mut image: Option<Box<[u8]>> = None;
 
+    let has_better_tag = tagged_file
+        .tags()
+        .iter()
+        .any(|tag| tag.tag_type() != TagType::Id3v1);
+
     for tag in tagged_file.tags() {
+        if has_better_tag && tag.tag_type() == TagType::Id3v1 {
+            continue;
+        }
+
         for item in tag.items() {
             if let Some(meta_tag) = map_standard_tag(item) {
                 apply_tag(meta_tag, &mut metadata);


### PR DESCRIPTION
## Summary
When an album has both ID3v2 and ID3v1 tags, sometimes ID3v1 tags would be preferred over other formats, leading to incorrect/corrupt metadata.

## Changes
<!-- What specific changes were made? -->

## Testing
<!-- How did you test these changes? -->

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
