### PR TITLE
feat: loop point

### DIFF
--- a/src/media/builtin/lofty.rs
+++ b/src/media/builtin/lofty.rs
@@ -257,6 +257,8 @@ impl MediaStream for LoftyStream {
     ) -> Result<F32DecodeResult, PlaybackReadError> {
         Err(PlaybackReadError::InvalidState)
     }
+
+    fn set_looping(&mut self, _enabled: bool) {}
 }
 
 #[cfg(test)]

--- a/src/media/builtin/symphonia.rs
+++ b/src/media/builtin/symphonia.rs
@@ -74,6 +74,17 @@ pub struct SymphoniaStream {
     last_image: Option<Visual>,
     /// Pre-allocated buffer for sample format conversion, reused across decode calls
     conversion_buffer: Vec<Vec<f64>>,
+    /// Whether loop-point-aware decoding is active
+    looping: bool,
+    /// Loop start point in seconds (from LOOP_START metadata)
+    loop_start_seconds: Option<f64>,
+    /// Loop end point in seconds (from LOOP_END metadata)
+    loop_end_seconds: Option<f64>,
+    /// Set when a seek to loop_start is needed on the next decode call
+    pending_loop_seek: bool,
+    /// Set to true after a loop seek; the next decoded packet may need its
+    /// leading samples trimmed if the seek landed before the exact loop_start time
+    needs_loop_start_trim: bool,
 }
 
 impl SymphoniaStream {
@@ -181,7 +192,7 @@ impl SymphoniaStream {
                     Self::tag_to_string(&tag.value).map(MetadataTag::DiscSubtitle)
                 }
                 _ => {
-                    let key = tag.key.as_str();
+                    let key = tag.key.as_str().trim_start_matches("TXXX:");
                     if key.eq_ignore_ascii_case("REPLAYGAIN_TRACK_GAIN") {
                         Self::tag_to_string(&tag.value).map(MetadataTag::ReplayGainTrackGain)
                     } else if key.eq_ignore_ascii_case("REPLAYGAIN_TRACK_PEAK") {
@@ -194,8 +205,17 @@ impl SymphoniaStream {
                         Self::tag_to_string(&tag.value).map(MetadataTag::R128TrackGain)
                     } else if key.eq_ignore_ascii_case("R128_ALBUM_GAIN") {
                         Self::tag_to_string(&tag.value).map(MetadataTag::R128AlbumGain)
-                    } else if key.eq_ignore_ascii_case("TXXX:MusicBrainz Album Id") {
+                    } else if key.eq_ignore_ascii_case("MusicBrainz Album Id") {
                         Self::tag_to_string(&tag.value).map(MetadataTag::MbidAlbum)
+                    } else if key.eq_ignore_ascii_case("LOOP_START") {
+                        Self::tag_to_string(&tag.value)
+                            .and_then(|v| v.parse::<f64>().ok())
+                            // Convert from microseconds to seconds
+                            .map(|v| MetadataTag::LoopStart(v / 1_000_000.0))
+                    } else if key.eq_ignore_ascii_case("LOOP_END") {
+                        Self::tag_to_string(&tag.value)
+                            .and_then(|v| v.parse::<f64>().ok())
+                            .map(|v| MetadataTag::LoopEnd(v / 1_000_000.0))
                     } else {
                         None
                     }
@@ -263,6 +283,11 @@ impl MediaProvider for SymphoniaProvider {
             pending_metadata_update: false,
             last_image: None,
             conversion_buffer: Vec::new(),
+            looping: false,
+            loop_start_seconds: None,
+            loop_end_seconds: None,
+            pending_loop_seek: false,
+            needs_loop_start_trim: false,
         };
 
         stream.read_base_metadata(&mut probed);
@@ -562,13 +587,49 @@ impl MediaStream for SymphoniaStream {
         };
 
         loop {
+            // Handle pending loop seek (after truncating at loop_end)
+            if self.pending_loop_seek {
+                if let Some(loop_start) = self.loop_start_seconds {
+                    format
+                        .seek(
+                            SeekMode::Accurate,
+                            SeekTo::Time {
+                                time: Time {
+                                    seconds: loop_start as u64,
+                                    frac: loop_start.fract(),
+                                },
+                                track_id: Some(self.current_track),
+                            },
+                        )
+                        .ok();
+                }
+                self.pending_loop_seek = false;
+                self.needs_loop_start_trim = true;
+            }
+
             let packet = match format.next_packet() {
                 Ok(packet) => packet,
-                Err(Error::ResetRequired) => return Ok(DecodeResult::Eof),
-                Err(Error::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                Err(Error::ResetRequired) => {
+                    if self.looping && self.loop_start_seconds.is_some() {
+                        self.pending_loop_seek = true;
+                        continue;
+                    }
                     return Ok(DecodeResult::Eof);
                 }
-                Err(_) => return Ok(DecodeResult::Eof),
+                Err(Error::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    if self.looping && self.loop_start_seconds.is_some() {
+                        self.pending_loop_seek = true;
+                        continue;
+                    }
+                    return Ok(DecodeResult::Eof);
+                }
+                Err(_) => {
+                    if self.looping && self.loop_start_seconds.is_some() {
+                        self.pending_loop_seek = true;
+                        continue;
+                    }
+                    return Ok(DecodeResult::Eof);
+                }
             };
 
             while !format.metadata().is_latest() {
@@ -593,6 +654,56 @@ impl MediaStream for SymphoniaStream {
                         self.current_position_ms = time_to_millis(tb.calc_time(packet.ts()));
                     }
 
+                    // Handle beginning trim after a loop seek: the seek may land at
+                    // a packet boundary before loop_start, so skip those leading samples
+                    let start_offset = if self.needs_loop_start_trim {
+                        self.needs_loop_start_trim = false;
+                        if let (Some(loop_start), Some(tb)) =
+                            (self.loop_start_seconds, &self.current_timebase)
+                        {
+                            let current_time = tb.calc_time(packet.ts());
+                            let current_secs = current_time.seconds as f64 + current_time.frac;
+                            if current_secs < loop_start {
+                                ((loop_start - current_secs) * rate as f64) as usize
+                            } else {
+                                0
+                            }
+                        } else {
+                            0
+                        }
+                    } else {
+                        0
+                    };
+
+                    let after_start = decoded.frames().saturating_sub(start_offset);
+                    if after_start == 0 {
+                        continue;
+                    }
+
+                    // Determine if we need to truncate at loop_end
+                    let (max_samples, needs_loop_seek) = if self.looping
+                        && let Some(loop_end) = self.loop_end_seconds
+                        && let Some(tb) = &self.current_timebase
+                    {
+                        let current_time = tb.calc_time(packet.ts());
+                        let current_secs = current_time.seconds as f64 + current_time.frac;
+                        let frame_start = current_secs + start_offset as f64 / rate as f64;
+                        let frame_secs = after_start as f64 / rate as f64;
+
+                        if frame_start + frame_secs > loop_end {
+                            let keep = ((loop_end - frame_start).max(0.0) * rate as f64) as usize;
+                            if keep == 0 {
+                                self.pending_loop_seek = true;
+                                continue;
+                            }
+                            (keep, true)
+                        } else {
+                            (after_start, false)
+                        }
+                    } else {
+                        (after_start, false)
+                    };
+
                     // prepare buffers
                     while self.conversion_buffer.len() < channel_count {
                         self.conversion_buffer
@@ -607,81 +718,140 @@ impl MediaStream for SymphoniaStream {
                     let frames = match decoded {
                         AudioBufferRef::U8(v) => {
                             for ch in 0..channel_count {
-                                self.conversion_buffer[ch]
-                                    .extend(v.chan(ch).iter().map(|&s| s.sample_into()));
+                                self.conversion_buffer[ch].extend(
+                                    v.chan(ch)
+                                        .iter()
+                                        .skip(start_offset)
+                                        .take(max_samples)
+                                        .map(|&s| s.sample_into()),
+                                );
                             }
-                            v.frames()
+                            max_samples
                         }
                         AudioBufferRef::U16(v) => {
                             for ch in 0..channel_count {
-                                self.conversion_buffer[ch]
-                                    .extend(v.chan(ch).iter().map(|&s| s.sample_into()));
+                                self.conversion_buffer[ch].extend(
+                                    v.chan(ch)
+                                        .iter()
+                                        .skip(start_offset)
+                                        .take(max_samples)
+                                        .map(|&s| s.sample_into()),
+                                );
                             }
-                            v.frames()
+                            max_samples
                         }
                         AudioBufferRef::U24(v) => {
                             for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(v.chan(ch).iter().map(|s| {
-                                    U24::try_from(s.0).expect("u24 overflow").sample_into()
-                                }));
+                                self.conversion_buffer[ch].extend(
+                                    v.chan(ch).iter().skip(start_offset).take(max_samples).map(
+                                        |s| U24::try_from(s.0).expect("u24 overflow").sample_into(),
+                                    ),
+                                );
                             }
-                            v.frames()
+                            max_samples
                         }
                         AudioBufferRef::U32(v) => {
                             for ch in 0..channel_count {
-                                self.conversion_buffer[ch]
-                                    .extend(v.chan(ch).iter().map(|&s| s.sample_into()));
+                                self.conversion_buffer[ch].extend(
+                                    v.chan(ch)
+                                        .iter()
+                                        .skip(start_offset)
+                                        .take(max_samples)
+                                        .map(|&s| s.sample_into()),
+                                );
                             }
-                            v.frames()
+                            max_samples
                         }
                         AudioBufferRef::S8(v) => {
                             for ch in 0..channel_count {
-                                self.conversion_buffer[ch]
-                                    .extend(v.chan(ch).iter().map(|&s| s.sample_into()));
+                                self.conversion_buffer[ch].extend(
+                                    v.chan(ch)
+                                        .iter()
+                                        .skip(start_offset)
+                                        .take(max_samples)
+                                        .map(|&s| s.sample_into()),
+                                );
                             }
-                            v.frames()
+                            max_samples
                         }
                         AudioBufferRef::S16(v) => {
                             for ch in 0..channel_count {
-                                self.conversion_buffer[ch]
-                                    .extend(v.chan(ch).iter().map(|&s| s.sample_into()));
+                                self.conversion_buffer[ch].extend(
+                                    v.chan(ch)
+                                        .iter()
+                                        .skip(start_offset)
+                                        .take(max_samples)
+                                        .map(|&s| s.sample_into()),
+                                );
                             }
-                            v.frames()
+                            max_samples
                         }
                         AudioBufferRef::S24(v) => {
                             for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(v.chan(ch).iter().map(|s| {
-                                    I24::try_from(s.0).expect("i24 overflow").sample_into()
-                                }));
+                                self.conversion_buffer[ch].extend(
+                                    v.chan(ch).iter().skip(start_offset).take(max_samples).map(
+                                        |s| I24::try_from(s.0).expect("i24 overflow").sample_into(),
+                                    ),
+                                );
                             }
-                            v.frames()
+                            max_samples
                         }
                         AudioBufferRef::S32(v) => {
                             for ch in 0..channel_count {
-                                self.conversion_buffer[ch]
-                                    .extend(v.chan(ch).iter().map(|&s| s.sample_into()));
+                                self.conversion_buffer[ch].extend(
+                                    v.chan(ch)
+                                        .iter()
+                                        .skip(start_offset)
+                                        .take(max_samples)
+                                        .map(|&s| s.sample_into()),
+                                );
                             }
-                            v.frames()
+                            max_samples
                         }
                         AudioBufferRef::F32(v) => {
                             for ch in 0..channel_count {
-                                self.conversion_buffer[ch]
-                                    .extend(v.chan(ch).iter().map(|&s| s.sample_into()));
+                                self.conversion_buffer[ch].extend(
+                                    v.chan(ch)
+                                        .iter()
+                                        .skip(start_offset)
+                                        .take(max_samples)
+                                        .map(|&s| s.sample_into()),
+                                );
                             }
-                            v.frames()
+                            max_samples
                         }
                         AudioBufferRef::F64(v) => {
-                            let slices: SmallVec<[&[f64]; 8]> =
-                                (0..channel_count).map(|ch| v.chan(ch)).collect();
-                            output.write_slices(&slices[..channel_count]);
+                            if needs_loop_seek || start_offset > 0 {
+                                for ch in 0..channel_count {
+                                    self.conversion_buffer[ch].extend(
+                                        v.chan(ch)
+                                            .iter()
+                                            .skip(start_offset)
+                                            .take(max_samples)
+                                            .map(|&s| s.sample_into()),
+                                    );
+                                }
+                                output.write_vecs(&self.conversion_buffer[..channel_count]);
+                            } else {
+                                let slices: SmallVec<[&[f64]; 8]> =
+                                    (0..channel_count).map(|ch| v.chan(ch)).collect();
+                                output.write_slices(&slices[..channel_count]);
+                            }
+                            if needs_loop_seek {
+                                self.pending_loop_seek = true;
+                            }
                             return Ok(DecodeResult::Decoded {
-                                frames: v.frames(),
+                                frames: max_samples,
                                 rate,
                             });
                         }
                     };
 
                     output.write_vecs(&self.conversion_buffer[..channel_count]);
+
+                    if needs_loop_seek {
+                        self.pending_loop_seek = true;
+                    }
 
                     return Ok(DecodeResult::Decoded { frames, rate });
                 }
@@ -704,15 +874,49 @@ impl MediaStream for SymphoniaStream {
         };
 
         loop {
+            // Handle pending loop seek (after truncating at loop_end)
+            if self.pending_loop_seek {
+                if let Some(loop_start) = self.loop_start_seconds {
+                    format
+                        .seek(
+                            SeekMode::Accurate,
+                            SeekTo::Time {
+                                time: Time {
+                                    seconds: loop_start as u64,
+                                    frac: loop_start.fract(),
+                                },
+                                track_id: Some(self.current_track),
+                            },
+                        )
+                        .ok();
+                }
+                self.pending_loop_seek = false;
+                self.needs_loop_start_trim = true;
+            }
+
             let packet = match format.next_packet() {
                 Ok(packet) => packet,
                 Err(Error::ResetRequired) => {
+                    if self.looping && self.loop_start_seconds.is_some() {
+                        self.pending_loop_seek = true;
+                        continue;
+                    }
                     return Ok(F32DecodeResult::Decoded(DecodeResult::Eof));
                 }
                 Err(Error::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    if self.looping && self.loop_start_seconds.is_some() {
+                        self.pending_loop_seek = true;
+                        continue;
+                    }
                     return Ok(F32DecodeResult::Decoded(DecodeResult::Eof));
                 }
-                Err(_) => return Ok(F32DecodeResult::Decoded(DecodeResult::Eof)),
+                Err(_) => {
+                    if self.looping && self.loop_start_seconds.is_some() {
+                        self.pending_loop_seek = true;
+                        continue;
+                    }
+                    return Ok(F32DecodeResult::Decoded(DecodeResult::Eof));
+                }
             };
 
             while !format.metadata().is_latest() {
@@ -737,16 +941,77 @@ impl MediaStream for SymphoniaStream {
                         self.current_position_ms = time_to_millis(tb.calc_time(packet.ts()));
                     }
 
+                    // Handle beginning trim after a loop seek: the seek may land at
+                    // a packet boundary before loop_start, so skip those leading samples
+                    let start_offset = if self.needs_loop_start_trim {
+                        self.needs_loop_start_trim = false;
+                        if let (Some(loop_start), Some(tb)) =
+                            (self.loop_start_seconds, &self.current_timebase)
+                        {
+                            let current_time = tb.calc_time(packet.ts());
+                            let current_secs = current_time.seconds as f64 + current_time.frac;
+                            if current_secs < loop_start {
+                                ((loop_start - current_secs) * rate as f64) as usize
+                            } else {
+                                0
+                            }
+                        } else {
+                            0
+                        }
+                    } else {
+                        0
+                    };
+
+                    let after_start = decoded.frames().saturating_sub(start_offset);
+                    if after_start == 0 {
+                        continue;
+                    }
+
+                    // Determine if we need to truncate at loop_end
+                    let (max_samples, needs_loop_seek) = if self.looping
+                        && let Some(loop_end) = self.loop_end_seconds
+                        && let Some(tb) = &self.current_timebase
+                    {
+                        let current_time = tb.calc_time(packet.ts());
+                        let current_secs = current_time.seconds as f64 + current_time.frac;
+                        let frame_start = current_secs + start_offset as f64 / rate as f64;
+                        let frame_secs = after_start as f64 / rate as f64;
+
+                        if frame_start + frame_secs > loop_end {
+                            let keep = ((loop_end - frame_start).max(0.0) * rate as f64) as usize;
+                            if keep == 0 {
+                                self.pending_loop_seek = true;
+                                continue;
+                            }
+                            (keep, true)
+                        } else {
+                            (after_start, false)
+                        }
+                    } else {
+                        (after_start, false)
+                    };
+
                     // Only handle F32, return NotF32 for other formats
                     let frames = match decoded {
                         AudioBufferRef::F32(v) => {
-                            let slices: SmallVec<[&[f32]; 8]> =
-                                (0..channel_count).map(|ch| v.chan(ch)).collect();
-                            output.write_slices(&slices);
-                            v.frames()
+                            if needs_loop_seek || start_offset > 0 {
+                                let slices: SmallVec<[&[f32]; 8]> = (0..channel_count)
+                                    .map(|ch| &v.chan(ch)[start_offset..start_offset + max_samples])
+                                    .collect();
+                                output.write_slices(&slices);
+                            } else {
+                                let slices: SmallVec<[&[f32]; 8]> =
+                                    (0..channel_count).map(|ch| v.chan(ch)).collect();
+                                output.write_slices(&slices);
+                            }
+                            max_samples
                         }
                         _ => return Ok(F32DecodeResult::NotF32),
                     };
+
+                    if needs_loop_seek {
+                        self.pending_loop_seek = true;
+                    }
 
                     return Ok(F32DecodeResult::Decoded(DecodeResult::Decoded {
                         frames,
@@ -760,6 +1025,21 @@ impl MediaStream for SymphoniaStream {
                     return Err(PlaybackReadError::DecodeFatal(e.to_string()));
                 }
             }
+        }
+    }
+
+    fn set_looping(&mut self, enabled: bool) {
+        self.looping = enabled;
+        if enabled {
+            self.loop_start_seconds = self.current_metadata.loop_start;
+            self.loop_end_seconds = self.current_metadata.loop_end;
+            self.pending_loop_seek = false;
+            self.needs_loop_start_trim = false;
+        } else {
+            self.loop_start_seconds = None;
+            self.loop_end_seconds = None;
+            self.pending_loop_seek = false;
+            self.needs_loop_start_trim = false;
         }
     }
 }

--- a/src/media/builtin/symphonia.rs
+++ b/src/media/builtin/symphonia.rs
@@ -247,6 +247,88 @@ impl SymphoniaStream {
 
         self.pending_metadata_update = true;
     }
+
+    fn loop_seek_if_pending(&mut self) -> Result<(), PlaybackReadError> {
+        if !self.pending_loop_seek {
+            return Ok(());
+        }
+        let Some(format) = self.format.as_mut() else {
+            return Err(PlaybackReadError::InvalidState);
+        };
+        if let Some(loop_start) = self.loop_start_seconds
+            && format
+                .seek(
+                    SeekMode::Accurate,
+                    SeekTo::Time {
+                        time: Time {
+                            seconds: loop_start as u64,
+                            frac: loop_start.fract(),
+                        },
+                        track_id: Some(self.current_track),
+                    },
+                )
+                .is_err()
+        {
+            return Err(PlaybackReadError::Eof);
+        }
+        self.pending_loop_seek = false;
+        self.needs_loop_start_trim = true;
+        Ok(())
+    }
+
+    fn try_loop_on_eof(&mut self) -> bool {
+        if self.looping && self.loop_start_seconds.is_some() {
+            self.pending_loop_seek = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn compute_loop_start_offset(
+        loop_start_seconds: Option<f64>,
+        timebase: Option<TimeBase>,
+        packet_ts: u64,
+        rate: u32,
+    ) -> usize {
+        let (Some(loop_start), Some(tb)) = (loop_start_seconds, timebase) else {
+            return 0;
+        };
+        let current_time = tb.calc_time(packet_ts);
+        let current_secs = current_time.seconds as f64 + current_time.frac;
+        if current_secs < loop_start {
+            ((loop_start - current_secs) * rate as f64) as usize
+        } else {
+            0
+        }
+    }
+
+    fn compute_loop_window(
+        looping: bool,
+        loop_end_seconds: Option<f64>,
+        timebase: Option<TimeBase>,
+        packet_ts: u64,
+        start_offset: usize,
+        after_start: usize,
+        rate: u32,
+    ) -> (usize, bool) {
+        if !looping {
+            return (after_start, false);
+        }
+        let (Some(loop_end), Some(tb)) = (loop_end_seconds, timebase) else {
+            return (after_start, false);
+        };
+        let current_time = tb.calc_time(packet_ts);
+        let current_secs = current_time.seconds as f64 + current_time.frac;
+        let frame_start = current_secs + start_offset as f64 / rate as f64;
+        let frame_secs = after_start as f64 / rate as f64;
+        if frame_start + frame_secs > loop_end {
+            let keep = ((loop_end - frame_start).max(0.0) * rate as f64) as usize;
+            (keep, true)
+        } else {
+            (after_start, false)
+        }
+    }
 }
 
 impl MediaProvider for SymphoniaProvider {
@@ -586,53 +668,19 @@ impl MediaStream for SymphoniaStream {
         &mut self,
         output: &ChannelProducers<f64>,
     ) -> Result<DecodeResult, PlaybackReadError> {
-        let Some(format) = &mut self.format else {
+        if self.format.is_none() {
             return Err(PlaybackReadError::InvalidState);
-        };
+        }
 
         loop {
-            // Handle pending loop seek (after truncating at loop_end)
-            if self.pending_loop_seek {
-                if let Some(loop_start) = self.loop_start_seconds
-                    && format
-                        .seek(
-                            SeekMode::Accurate,
-                            SeekTo::Time {
-                                time: Time {
-                                    seconds: loop_start as u64,
-                                    frac: loop_start.fract(),
-                                },
-                                track_id: Some(self.current_track),
-                            },
-                        )
-                        .is_err()
-                {
-                    return Err(PlaybackReadError::Eof);
-                }
+            self.loop_seek_if_pending()?;
 
-                self.pending_loop_seek = false;
-                self.needs_loop_start_trim = true;
-            }
+            let format = self.format.as_mut().expect("format presence checked above");
 
             let packet = match format.next_packet() {
                 Ok(packet) => packet,
-                Err(Error::ResetRequired) => {
-                    if self.looping && self.loop_start_seconds.is_some() {
-                        self.pending_loop_seek = true;
-                        continue;
-                    }
-                    return Ok(DecodeResult::Eof);
-                }
-                Err(Error::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                    if self.looping && self.loop_start_seconds.is_some() {
-                        self.pending_loop_seek = true;
-                        continue;
-                    }
-                    return Ok(DecodeResult::Eof);
-                }
                 Err(_) => {
-                    if self.looping && self.loop_start_seconds.is_some() {
-                        self.pending_loop_seek = true;
+                    if self.try_loop_on_eof() {
                         continue;
                     }
                     return Ok(DecodeResult::Eof);
@@ -661,23 +709,14 @@ impl MediaStream for SymphoniaStream {
                         self.current_position_ms = time_to_millis(tb.calc_time(packet.ts()));
                     }
 
-                    // Handle beginning trim after a loop seek: the seek may land at
-                    // a packet boundary before loop_start, so skip those leading samples
                     let start_offset = if self.needs_loop_start_trim {
                         self.needs_loop_start_trim = false;
-                        if let (Some(loop_start), Some(tb)) =
-                            (self.loop_start_seconds, &self.current_timebase)
-                        {
-                            let current_time = tb.calc_time(packet.ts());
-                            let current_secs = current_time.seconds as f64 + current_time.frac;
-                            if current_secs < loop_start {
-                                ((loop_start - current_secs) * rate as f64) as usize
-                            } else {
-                                0
-                            }
-                        } else {
-                            0
-                        }
+                        Self::compute_loop_start_offset(
+                            self.loop_start_seconds,
+                            self.current_timebase,
+                            packet.ts(),
+                            rate,
+                        )
                     } else {
                         0
                     };
@@ -687,31 +726,21 @@ impl MediaStream for SymphoniaStream {
                         continue;
                     }
 
-                    // Determine if we need to truncate at loop_end
-                    let (max_samples, needs_loop_seek) = if self.looping
-                        && let Some(loop_end) = self.loop_end_seconds
-                        && let Some(tb) = &self.current_timebase
-                    {
-                        let current_time = tb.calc_time(packet.ts());
-                        let current_secs = current_time.seconds as f64 + current_time.frac;
-                        let frame_start = current_secs + start_offset as f64 / rate as f64;
-                        let frame_secs = after_start as f64 / rate as f64;
+                    let (max_samples, needs_loop_seek) = Self::compute_loop_window(
+                        self.looping,
+                        self.loop_end_seconds,
+                        self.current_timebase,
+                        packet.ts(),
+                        start_offset,
+                        after_start,
+                        rate,
+                    );
 
-                        if frame_start + frame_secs > loop_end {
-                            let keep = ((loop_end - frame_start).max(0.0) * rate as f64) as usize;
-                            if keep == 0 {
-                                self.pending_loop_seek = true;
-                                continue;
-                            }
-                            (keep, true)
-                        } else {
-                            (after_start, false)
-                        }
-                    } else {
-                        (after_start, false)
-                    };
+                    if needs_loop_seek && max_samples == 0 {
+                        self.pending_loop_seek = true;
+                        continue;
+                    }
 
-                    // prepare buffers
                     while self.conversion_buffer.len() < channel_count {
                         self.conversion_buffer
                             .push(Vec::with_capacity(decoded.frames()));
@@ -721,129 +750,39 @@ impl MediaStream for SymphoniaStream {
                         buf.clear();
                     }
 
-                    // convert - shouldn't lose any quality
-                    let frames = match decoded {
-                        AudioBufferRef::U8(v) => {
+                    macro_rules! convert_chan {
+                        ($v:ident, $convert:expr) => {{
                             for ch in 0..channel_count {
                                 self.conversion_buffer[ch].extend(
-                                    v.chan(ch)
+                                    $v.chan(ch)
                                         .iter()
                                         .skip(start_offset)
                                         .take(max_samples)
-                                        .map(|&s| s.sample_into()),
+                                        .map($convert),
                                 );
                             }
-                            max_samples
-                        }
-                        AudioBufferRef::U16(v) => {
-                            for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(
-                                    v.chan(ch)
-                                        .iter()
-                                        .skip(start_offset)
-                                        .take(max_samples)
-                                        .map(|&s| s.sample_into()),
-                                );
-                            }
-                            max_samples
-                        }
-                        AudioBufferRef::U24(v) => {
-                            for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(
-                                    v.chan(ch).iter().skip(start_offset).take(max_samples).map(
-                                        |s| U24::try_from(s.0).expect("u24 overflow").sample_into(),
-                                    ),
-                                );
-                            }
-                            max_samples
-                        }
-                        AudioBufferRef::U32(v) => {
-                            for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(
-                                    v.chan(ch)
-                                        .iter()
-                                        .skip(start_offset)
-                                        .take(max_samples)
-                                        .map(|&s| s.sample_into()),
-                                );
-                            }
-                            max_samples
-                        }
-                        AudioBufferRef::S8(v) => {
-                            for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(
-                                    v.chan(ch)
-                                        .iter()
-                                        .skip(start_offset)
-                                        .take(max_samples)
-                                        .map(|&s| s.sample_into()),
-                                );
-                            }
-                            max_samples
-                        }
-                        AudioBufferRef::S16(v) => {
-                            for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(
-                                    v.chan(ch)
-                                        .iter()
-                                        .skip(start_offset)
-                                        .take(max_samples)
-                                        .map(|&s| s.sample_into()),
-                                );
-                            }
-                            max_samples
-                        }
-                        AudioBufferRef::S24(v) => {
-                            for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(
-                                    v.chan(ch).iter().skip(start_offset).take(max_samples).map(
-                                        |s| I24::try_from(s.0).expect("i24 overflow").sample_into(),
-                                    ),
-                                );
-                            }
-                            max_samples
-                        }
-                        AudioBufferRef::S32(v) => {
-                            for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(
-                                    v.chan(ch)
-                                        .iter()
-                                        .skip(start_offset)
-                                        .take(max_samples)
-                                        .map(|&s| s.sample_into()),
-                                );
-                            }
-                            max_samples
-                        }
-                        AudioBufferRef::F32(v) => {
-                            for ch in 0..channel_count {
-                                self.conversion_buffer[ch].extend(
-                                    v.chan(ch)
-                                        .iter()
-                                        .skip(start_offset)
-                                        .take(max_samples)
-                                        .map(|&s| s.sample_into()),
-                                );
-                            }
-                            max_samples
-                        }
+                        }};
+                    }
+
+                    match decoded {
+                        AudioBufferRef::U8(v) => convert_chan!(v, |&s| s.sample_into()),
+                        AudioBufferRef::U16(v) => convert_chan!(v, |&s| s.sample_into()),
+                        AudioBufferRef::U24(v) => convert_chan!(v, |s| {
+                            U24::try_from(s.0).expect("u24 overflow").sample_into()
+                        }),
+                        AudioBufferRef::U32(v) => convert_chan!(v, |&s| s.sample_into()),
+                        AudioBufferRef::S8(v) => convert_chan!(v, |&s| s.sample_into()),
+                        AudioBufferRef::S16(v) => convert_chan!(v, |&s| s.sample_into()),
+                        AudioBufferRef::S24(v) => convert_chan!(v, |s| {
+                            I24::try_from(s.0).expect("i24 overflow").sample_into()
+                        }),
+                        AudioBufferRef::S32(v) => convert_chan!(v, |&s| s.sample_into()),
+                        AudioBufferRef::F32(v) => convert_chan!(v, |&s| s.sample_into()),
                         AudioBufferRef::F64(v) => {
-                            if needs_loop_seek || start_offset > 0 {
-                                for ch in 0..channel_count {
-                                    self.conversion_buffer[ch].extend(
-                                        v.chan(ch)
-                                            .iter()
-                                            .skip(start_offset)
-                                            .take(max_samples)
-                                            .map(|&s| s.sample_into()),
-                                    );
-                                }
-                                output.write_vecs(&self.conversion_buffer[..channel_count]);
-                            } else {
-                                let slices: SmallVec<[&[f64]; 8]> =
-                                    (0..channel_count).map(|ch| v.chan(ch)).collect();
-                                output.write_slices(&slices[..channel_count]);
-                            }
+                            let slices: SmallVec<[&[f64]; 8]> = (0..channel_count)
+                                .map(|ch| &v.chan(ch)[start_offset..start_offset + max_samples])
+                                .collect();
+                            output.write_slices(&slices[..channel_count]);
                             if needs_loop_seek {
                                 self.pending_loop_seek = true;
                             }
@@ -852,7 +791,7 @@ impl MediaStream for SymphoniaStream {
                                 rate,
                             });
                         }
-                    };
+                    }
 
                     output.write_vecs(&self.conversion_buffer[..channel_count]);
 
@@ -860,7 +799,10 @@ impl MediaStream for SymphoniaStream {
                         self.pending_loop_seek = true;
                     }
 
-                    return Ok(DecodeResult::Decoded { frames, rate });
+                    return Ok(DecodeResult::Decoded {
+                        frames: max_samples,
+                        rate,
+                    });
                 }
                 Err(Error::IoError(_)) | Err(Error::DecodeError(_)) => {
                     continue;
@@ -876,53 +818,17 @@ impl MediaStream for SymphoniaStream {
         &mut self,
         output: &ChannelProducers<f32>,
     ) -> Result<F32DecodeResult, PlaybackReadError> {
-        let Some(format) = &mut self.format else {
+        if self.format.is_none() {
             return Err(PlaybackReadError::InvalidState);
-        };
+        }
 
         loop {
-            // Handle pending loop seek (after truncating at loop_end)
-            if self.pending_loop_seek {
-                if let Some(loop_start) = self.loop_start_seconds
-                    && format
-                        .seek(
-                            SeekMode::Accurate,
-                            SeekTo::Time {
-                                time: Time {
-                                    seconds: loop_start as u64,
-                                    frac: loop_start.fract(),
-                                },
-                                track_id: Some(self.current_track),
-                            },
-                        )
-                        .is_err()
-                {
-                    return Err(PlaybackReadError::Eof);
-                }
-
-                self.pending_loop_seek = false;
-                self.needs_loop_start_trim = true;
-            }
-
+            self.loop_seek_if_pending()?;
+            let format = self.format.as_mut().expect("format presence checked above");
             let packet = match format.next_packet() {
                 Ok(packet) => packet,
-                Err(Error::ResetRequired) => {
-                    if self.looping && self.loop_start_seconds.is_some() {
-                        self.pending_loop_seek = true;
-                        continue;
-                    }
-                    return Ok(F32DecodeResult::Decoded(DecodeResult::Eof));
-                }
-                Err(Error::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                    if self.looping && self.loop_start_seconds.is_some() {
-                        self.pending_loop_seek = true;
-                        continue;
-                    }
-                    return Ok(F32DecodeResult::Decoded(DecodeResult::Eof));
-                }
                 Err(_) => {
-                    if self.looping && self.loop_start_seconds.is_some() {
-                        self.pending_loop_seek = true;
+                    if self.try_loop_on_eof() {
                         continue;
                     }
                     return Ok(F32DecodeResult::Decoded(DecodeResult::Eof));
@@ -951,23 +857,14 @@ impl MediaStream for SymphoniaStream {
                         self.current_position_ms = time_to_millis(tb.calc_time(packet.ts()));
                     }
 
-                    // Handle beginning trim after a loop seek: the seek may land at
-                    // a packet boundary before loop_start, so skip those leading samples
                     let start_offset = if self.needs_loop_start_trim {
                         self.needs_loop_start_trim = false;
-                        if let (Some(loop_start), Some(tb)) =
-                            (self.loop_start_seconds, &self.current_timebase)
-                        {
-                            let current_time = tb.calc_time(packet.ts());
-                            let current_secs = current_time.seconds as f64 + current_time.frac;
-                            if current_secs < loop_start {
-                                ((loop_start - current_secs) * rate as f64) as usize
-                            } else {
-                                0
-                            }
-                        } else {
-                            0
-                        }
+                        Self::compute_loop_start_offset(
+                            self.loop_start_seconds,
+                            self.current_timebase,
+                            packet.ts(),
+                            rate,
+                        )
                     } else {
                         0
                     };
@@ -977,54 +874,37 @@ impl MediaStream for SymphoniaStream {
                         continue;
                     }
 
-                    // Determine if we need to truncate at loop_end
-                    let (max_samples, needs_loop_seek) = if self.looping
-                        && let Some(loop_end) = self.loop_end_seconds
-                        && let Some(tb) = &self.current_timebase
-                    {
-                        let current_time = tb.calc_time(packet.ts());
-                        let current_secs = current_time.seconds as f64 + current_time.frac;
-                        let frame_start = current_secs + start_offset as f64 / rate as f64;
-                        let frame_secs = after_start as f64 / rate as f64;
+                    let (max_samples, needs_loop_seek) = Self::compute_loop_window(
+                        self.looping,
+                        self.loop_end_seconds,
+                        self.current_timebase,
+                        packet.ts(),
+                        start_offset,
+                        after_start,
+                        rate,
+                    );
 
-                        if frame_start + frame_secs > loop_end {
-                            let keep = ((loop_end - frame_start).max(0.0) * rate as f64) as usize;
-                            if keep == 0 {
-                                self.pending_loop_seek = true;
-                                continue;
-                            }
-                            (keep, true)
-                        } else {
-                            (after_start, false)
-                        }
-                    } else {
-                        (after_start, false)
-                    };
+                    if needs_loop_seek && max_samples == 0 {
+                        self.pending_loop_seek = true;
+                        continue;
+                    }
 
-                    // Only handle F32, return NotF32 for other formats
-                    let frames = match decoded {
+                    match decoded {
                         AudioBufferRef::F32(v) => {
-                            if needs_loop_seek || start_offset > 0 {
-                                let slices: SmallVec<[&[f32]; 8]> = (0..channel_count)
-                                    .map(|ch| &v.chan(ch)[start_offset..start_offset + max_samples])
-                                    .collect();
-                                output.write_slices(&slices);
-                            } else {
-                                let slices: SmallVec<[&[f32]; 8]> =
-                                    (0..channel_count).map(|ch| v.chan(ch)).collect();
-                                output.write_slices(&slices);
-                            }
-                            max_samples
+                            let slices: SmallVec<[&[f32]; 8]> = (0..channel_count)
+                                .map(|ch| &v.chan(ch)[start_offset..start_offset + max_samples])
+                                .collect();
+                            output.write_slices(&slices);
                         }
                         _ => return Ok(F32DecodeResult::NotF32),
-                    };
+                    }
 
                     if needs_loop_seek {
                         self.pending_loop_seek = true;
                     }
 
                     return Ok(F32DecodeResult::Decoded(DecodeResult::Decoded {
-                        frames,
+                        frames: max_samples,
                         rate,
                     }));
                 }

--- a/src/media/builtin/symphonia.rs
+++ b/src/media/builtin/symphonia.rs
@@ -448,6 +448,10 @@ impl MediaStream for SymphoniaStream {
         let Some(format) = &mut self.format else {
             return Err(SeekError::InvalidState);
         };
+
+        self.pending_loop_seek = false;
+        self.needs_loop_start_trim = false;
+
         let seek = format
             .seek(
                 SeekMode::Accurate,
@@ -589,8 +593,8 @@ impl MediaStream for SymphoniaStream {
         loop {
             // Handle pending loop seek (after truncating at loop_end)
             if self.pending_loop_seek {
-                if let Some(loop_start) = self.loop_start_seconds {
-                    format
+                if let Some(loop_start) = self.loop_start_seconds
+                    && format
                         .seek(
                             SeekMode::Accurate,
                             SeekTo::Time {
@@ -601,8 +605,11 @@ impl MediaStream for SymphoniaStream {
                                 track_id: Some(self.current_track),
                             },
                         )
-                        .ok();
+                        .is_err()
+                {
+                    return Err(PlaybackReadError::Eof);
                 }
+
                 self.pending_loop_seek = false;
                 self.needs_loop_start_trim = true;
             }
@@ -876,8 +883,8 @@ impl MediaStream for SymphoniaStream {
         loop {
             // Handle pending loop seek (after truncating at loop_end)
             if self.pending_loop_seek {
-                if let Some(loop_start) = self.loop_start_seconds {
-                    format
+                if let Some(loop_start) = self.loop_start_seconds
+                    && format
                         .seek(
                             SeekMode::Accurate,
                             SeekTo::Time {
@@ -888,8 +895,11 @@ impl MediaStream for SymphoniaStream {
                                 track_id: Some(self.current_track),
                             },
                         )
-                        .ok();
+                        .is_err()
+                {
+                    return Err(PlaybackReadError::Eof);
                 }
+
                 self.pending_loop_seek = false;
                 self.needs_loop_start_trim = true;
             }

--- a/src/media/metadata.rs
+++ b/src/media/metadata.rs
@@ -51,6 +51,8 @@ pub enum MetadataTag {
     R128TrackGain(String),
     R128AlbumGain(String),
     DiscSubtitle(String),
+    LoopStart(f64),
+    LoopEnd(f64),
 }
 
 pub fn apply_tag(tag: MetadataTag, metadata: &mut Metadata) {
@@ -133,6 +135,8 @@ pub fn apply_tag(tag: MetadataTag, metadata: &mut Metadata) {
         MetadataTag::R128AlbumGain(v) => {
             metadata.replaygain_album_gain = parse_r128_gain_str(&v);
         }
+        MetadataTag::LoopStart(v) => metadata.loop_start = Some(v),
+        MetadataTag::LoopEnd(v) => metadata.loop_end = Some(v),
     }
 }
 
@@ -178,6 +182,9 @@ pub struct Metadata {
     pub replaygain_album_peak: Option<f64>,
 
     pub lyrics: Option<String>,
+
+    pub loop_start: Option<f64>,
+    pub loop_end: Option<f64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/media/traits.rs
+++ b/src/media/traits.rs
@@ -143,4 +143,13 @@ pub trait MediaStream {
         &mut self,
         output: &ChannelProducers<f32>,
     ) -> Result<F32DecodeResult, PlaybackReadError>;
+
+    /// Whether or not the media stream should attempt to use it's internal loop handling. With
+    /// Symphonia, the media stream will seek to the loop start point from the EOF or loop end
+    /// point when looping is enabled.
+    ///
+    /// This is handled by the media stream itself instead of the audio engine so that the media
+    /// stream implementation can handle the loop behavior natively (for example, if a tracker
+    /// module supports looping natively).
+    fn set_looping(&mut self, enabled: bool);
 }

--- a/src/playback/thread.rs
+++ b/src/playback/thread.rs
@@ -273,6 +273,10 @@ impl PlaybackThread {
 
         let info = self.engine.open(path)?;
 
+        // Enable loop-point-aware decoding if repeat-one is active
+        self.engine
+            .set_looping(self.queue.repeat_state() == RepeatState::RepeatingOne);
+
         self.send_event(PlaybackEvent::SongChanged(path.to_owned()));
 
         self.send_event(PlaybackEvent::DurationChanged(
@@ -769,7 +773,9 @@ impl PlaybackThread {
                     BACKGROUND_POSITION_BROADCAST_INTERVAL_MS
                 };
 
-                if self.last_broadcast_timestamp.saturating_add(min_interval) > timestamp {
+                if timestamp > self.last_broadcast_timestamp
+                    && self.last_broadcast_timestamp.saturating_add(min_interval) > timestamp
+                {
                     return;
                 }
             }
@@ -940,6 +946,7 @@ impl PlaybackThread {
     /// Sets the repeat mode.
     fn set_repeat(&mut self, state: RepeatState) {
         self.queue.set_repeat(state);
+        self.engine.set_looping(state == RepeatState::RepeatingOne);
 
         self.send_event(PlaybackEvent::RepeatChanged(self.queue.repeat_state()));
     }

--- a/src/playback/thread/audio_engine.rs
+++ b/src/playback/thread/audio_engine.rs
@@ -322,6 +322,11 @@ impl AudioEngine {
         // This method exists for future extensibility.
     }
 
+    /// Enable or disable loop-aware decoding on the media stream.
+    pub fn set_looping(&mut self, enabled: bool) {
+        self.media.set_looping(enabled);
+    }
+
     /// Process one cycle of the audio pipeline.
     ///
     /// Returns a result indicating whether to continue, handle EOF, or handle errors.

--- a/src/playback/thread/media_controller.rs
+++ b/src/playback/thread/media_controller.rs
@@ -196,6 +196,12 @@ impl MediaController {
             .ok_or(ChannelRetrievalError::NeverStarted)?
             .sample_rate()
     }
+
+    pub fn set_looping(&mut self, enabled: bool) {
+        if let Some(stream) = &mut self.media_stream {
+            stream.set_looping(enabled);
+        }
+    }
 }
 
 impl Default for MediaController {


### PR DESCRIPTION
## Summary
Closes #333.

Adds loop point handling to the Symphonia decoder and some code to use it throughout the audio pipeline. Not tested super well, I couldn't find great resources for this but it works with the limited information I do have.

## Changes
- Added a new `set_looping` function to the MediaProvider trait and implemented it for SymphoniaProvider.
- Repeat One now enables loop points.

## Testing
I tested it with the files I had that have loop_start metadata. I can't do a great test of loop_end but it should work.

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [x] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [x] Documentation added/updated where needed
- [ ] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md)
