### PR TITLE
test(scan): add more library tests

### DIFF
--- a/src/library/scan.rs
+++ b/src/library/scan.rs
@@ -1,4 +1,4 @@
-mod database;
+pub(crate) mod database;
 mod decode;
 mod discover;
 mod record;

--- a/src/library/scan/database.rs
+++ b/src/library/scan/database.rs
@@ -334,13 +334,7 @@ pub async fn update_metadata(
 
 #[cfg(test)]
 mod tests {
-    use super::bind_release_date;
-    use crate::{
-        library::types::{
-            DATE_PRECISION_FULL_DATE, DATE_PRECISION_YEAR, DATE_PRECISION_YEAR_MONTH,
-        },
-        media::metadata::Metadata,
-    };
+    use super::*;
     use chrono::{TimeZone, Utc};
 
     #[test]
@@ -386,5 +380,184 @@ mod tests {
                 Some(DATE_PRECISION_FULL_DATE),
             )
         );
+    }
+
+    use crate::test_support::{count_rows, create_test_pool, insert_metadata, track_metadata};
+
+    #[tokio::test]
+    async fn update_metadata_inserts_artist_album_track() {
+        let (dir, pool) = create_test_pool("db-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+        let path = dir.utf8_join("track.flac");
+
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+
+        assert_eq!(count_rows(&pool, "artist").await, 1);
+        assert_eq!(count_rows(&pool, "album").await, 1);
+        assert_eq!(count_rows(&pool, "track").await, 1);
+        assert_eq!(count_rows(&pool, "album_path").await, 1);
+    }
+
+    #[tokio::test]
+    async fn update_metadata_deduplicates_album() {
+        let (dir, pool) = create_test_pool("db-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let meta1 = track_metadata("Album", "Artist", "Track 1", 1);
+        let meta2 = track_metadata("Album", "Artist", "Track 2", 2);
+
+        insert_metadata(&mut conn, &meta1, &dir.utf8_join("track1.flac"))
+            .await
+            .unwrap();
+        insert_metadata(&mut conn, &meta2, &dir.utf8_join("track2.flac"))
+            .await
+            .unwrap();
+
+        assert_eq!(count_rows(&pool, "album").await, 1);
+        assert_eq!(count_rows(&pool, "artist").await, 1);
+        assert_eq!(count_rows(&pool, "track").await, 2);
+    }
+
+    #[tokio::test]
+    async fn update_metadata_keeps_different_artists_separate() {
+        let (dir, pool) = create_test_pool("db-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let mut meta1 = track_metadata("Album", "Artist A", "Track 1", 1);
+        meta1.mbid_album = Some("mbid-1".to_string());
+        let mut meta2 = track_metadata("Album", "Artist B", "Track 2", 1);
+        meta2.mbid_album = Some("mbid-2".to_string());
+
+        insert_metadata(&mut conn, &meta1, &dir.utf8_join("track1.flac"))
+            .await
+            .unwrap();
+        insert_metadata(&mut conn, &meta2, &dir.utf8_join("track2.flac"))
+            .await
+            .unwrap();
+
+        assert_eq!(count_rows(&pool, "album").await, 2);
+    }
+
+    #[tokio::test]
+    async fn update_metadata_updates_existing_track_title() {
+        let (dir, pool) = create_test_pool("db-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+        let path = dir.utf8_join("track.flac");
+
+        let mut meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+
+        meta.name = Some("Updated Track".to_string());
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+
+        let track: (String,) = sqlx::query_as("SELECT title FROM track WHERE location = $1")
+            .bind(path.as_str())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(track.0, "Updated Track");
+    }
+
+    #[tokio::test]
+    async fn update_metadata_rejects_mixed_folder_for_same_album_disc() {
+        let (dir, pool) = create_test_pool("db-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let folder_a = dir.join("disc1a");
+        let folder_b = dir.join("disc1b");
+        std::fs::create_dir_all(&folder_a).unwrap();
+        std::fs::create_dir_all(&folder_b).unwrap();
+
+        let path1 = Utf8PathBuf::from_path_buf(folder_a.join("track.flac")).unwrap();
+        let path2 = Utf8PathBuf::from_path_buf(folder_b.join("track.flac")).unwrap();
+
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path1).await.unwrap();
+        insert_metadata(&mut conn, &meta, &path2).await.unwrap();
+
+        assert_eq!(count_rows(&pool, "track").await, 1);
+    }
+
+    #[tokio::test]
+    async fn update_metadata_allows_same_album_different_disc_in_different_folder() {
+        let (dir, pool) = create_test_pool("db-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let folder_a = dir.join("disc1");
+        let folder_b = dir.join("disc2");
+        std::fs::create_dir_all(&folder_a).unwrap();
+        std::fs::create_dir_all(&folder_b).unwrap();
+
+        let path1 = Utf8PathBuf::from_path_buf(folder_a.join("track.flac")).unwrap();
+        let mut meta1 = track_metadata("Album", "Artist", "Track 1", 1);
+        meta1.disc_current = Some(1);
+
+        let path2 = Utf8PathBuf::from_path_buf(folder_b.join("track.flac")).unwrap();
+        let mut meta2 = track_metadata("Album", "Artist", "Track 2", 1);
+        meta2.disc_current = Some(2);
+
+        insert_metadata(&mut conn, &meta1, &path1).await.unwrap();
+        insert_metadata(&mut conn, &meta2, &path2).await.unwrap();
+
+        assert_eq!(count_rows(&pool, "track").await, 2);
+        assert_eq!(count_rows(&pool, "album_path").await, 2);
+    }
+
+    #[tokio::test]
+    async fn update_metadata_upserts_and_deletes_lyrics() {
+        let (dir, pool) = create_test_pool("db-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+        let path = dir.utf8_join("track.flac");
+
+        let mut meta = track_metadata("Album", "Artist", "Track", 1);
+        meta.lyrics = Some("hello lyrics".to_string());
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+        assert_eq!(count_rows(&pool, "lyrics").await, 1);
+
+        meta.lyrics = None;
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+        assert_eq!(count_rows(&pool, "lyrics").await, 0);
+    }
+
+    #[tokio::test]
+    async fn update_metadata_uses_album_artist_for_artist_row() {
+        let (dir, pool) = create_test_pool("db-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+        let path = dir.utf8_join("track.flac");
+
+        let mut meta = track_metadata("Album", "Artist", "Track", 1);
+        meta.artist = Some("Track Artist".to_string());
+        meta.album_artist = Some("Album Artist".to_string());
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+
+        let artist_name: (String,) = sqlx::query_as("SELECT name FROM artist")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(artist_name.0, "Album Artist");
+
+        let track_artist: (String,) = sqlx::query_as("SELECT artist_names FROM track")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(track_artist.0, "Track Artist");
+    }
+
+    #[tokio::test]
+    async fn update_metadata_uses_artist_sort() {
+        let (dir, pool) = create_test_pool("db-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+        let path = dir.utf8_join("track.flac");
+
+        let mut meta = track_metadata("Album", "Artist", "Track", 1);
+        meta.artist_sort = Some("Sorted Name".to_string());
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+
+        let sort_name: (String,) = sqlx::query_as("SELECT name_sortable FROM artist")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(sort_name.0, "Sorted Name");
     }
 }

--- a/src/library/scan/decode.rs
+++ b/src/library/scan/decode.rs
@@ -152,3 +152,114 @@ pub fn read_metadata_for_path(
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{TestDir, register_test_media_providers};
+    use std::fs;
+
+    #[test]
+    fn resolve_lyrics_prefers_sidecar() {
+        let dir = TestDir::new("decode-lyrics-test");
+        let track = dir.utf8_join("track.flac");
+        fs::write(&track, b"").unwrap();
+        fs::write(dir.join("track.lrc"), "[00:00.00] sidecar lyrics").unwrap();
+
+        let result = resolve_lyrics(&track, Some("[00:00.00] embedded lyrics".to_string()));
+        assert_eq!(result.as_deref(), Some("[00:00.00] sidecar lyrics"));
+    }
+
+    #[test]
+    fn resolve_lyrics_falls_back_to_embedded() {
+        let dir = TestDir::new("decode-lyrics-test");
+        let track = dir.utf8_join("track.flac");
+        fs::write(&track, b"").unwrap();
+
+        let result = resolve_lyrics(&track, Some("[00:00.00] embedded lyrics".to_string()));
+        assert_eq!(result.as_deref(), Some("[00:00.00] embedded lyrics"));
+    }
+
+    #[test]
+    fn resolve_lyrics_ignores_empty_sidecar() {
+        let dir = TestDir::new("decode-lyrics-test");
+        let track = dir.utf8_join("track.flac");
+        fs::write(&track, b"").unwrap();
+        fs::write(dir.join("track.lrc"), "   \n").unwrap();
+
+        let result = resolve_lyrics(&track, Some("[00:00.00] embedded lyrics".to_string()));
+        assert_eq!(result.as_deref(), Some("[00:00.00] embedded lyrics"));
+    }
+
+    #[test]
+    fn scan_path_for_album_art_finds_folder_jpg() {
+        let dir = TestDir::new("decode-art-test");
+        fs::write(dir.join("folder.jpg"), b"jpegbytes").unwrap();
+        let track = dir.utf8_join("track.flac");
+        fs::write(&track, b"").unwrap();
+
+        let mut cache = FxHashMap::default();
+        let result = scan_path_for_album_art(&track, &mut cache);
+        assert!(result.is_some());
+        assert_eq!(result.as_ref().unwrap().as_ref(), b"jpegbytes");
+    }
+
+    #[test]
+    fn scan_path_for_album_art_is_case_insensitive() {
+        let dir = TestDir::new("decode-art-test");
+        fs::write(dir.join("Folder.JPG"), b"jpegbytes").unwrap();
+        let track = dir.utf8_join("track.flac");
+        fs::write(&track, b"").unwrap();
+
+        let mut cache = FxHashMap::default();
+        let result = scan_path_for_album_art(&track, &mut cache);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn scan_path_for_album_art_caches_none() {
+        let dir = TestDir::new("decode-art-test");
+        let track = dir.utf8_join("track.flac");
+        fs::write(&track, b"").unwrap();
+
+        let mut cache = FxHashMap::default();
+        let result = scan_path_for_album_art(&track, &mut cache);
+        assert!(result.is_none());
+        assert_eq!(cache.get(&dir.utf8_path()), Some(&None));
+    }
+
+    #[test]
+    fn process_album_art_creates_thumbnail() {
+        let image = fs::read("assets/tests/audio-fixtures/cover.jpg").unwrap();
+        let (full, thumb) = process_album_art(&image).unwrap();
+        assert!(!full.is_empty());
+        assert!(thumb.starts_with(b"BM"));
+    }
+
+    #[test]
+    fn read_metadata_for_path_prefers_sidecar_lyrics() {
+        register_test_media_providers();
+        let dir = TestDir::new("decode-meta-test");
+        let src = std::path::Path::new("assets/tests/audio-fixtures/fixture.flac");
+        let track = dir.utf8_join("track.flac");
+        fs::copy(src, &track).unwrap();
+        fs::write(dir.join("track.lrc"), "[00:00.00] override lyrics").unwrap();
+
+        let mut cache = FxHashMap::default();
+        let info = read_metadata_for_path(&track, &mut cache).unwrap();
+        assert_eq!(info.0.lyrics.as_deref(), Some("[00:00.00] override lyrics"));
+    }
+
+    #[test]
+    fn read_metadata_for_path_keeps_embedded_lyrics_when_no_sidecar() {
+        register_test_media_providers();
+        let dir = TestDir::new("decode-meta-test");
+        let src = std::path::Path::new("assets/tests/audio-fixtures/fixture.flac");
+        let track = dir.utf8_join("track.flac");
+        fs::copy(src, &track).unwrap();
+
+        let mut cache = FxHashMap::default();
+        let info = read_metadata_for_path(&track, &mut cache).unwrap();
+        assert_eq!(info.0.lyrics.as_deref(), Some("[00:00.00] Test lyrics"));
+    }
+}

--- a/src/library/scan/discover.rs
+++ b/src/library/scan/discover.rs
@@ -457,8 +457,8 @@ mod tests {
     use crate::{
         settings::scan::MissingFolderPolicy,
         test_support::{
-            TestDir, create_test_pool, insert_metadata, register_test_media_providers,
-            track_metadata,
+            TestDir, add_track_to_playlist, count_rows, create_test_pool, insert_metadata,
+            register_test_media_providers, track_metadata,
         },
     };
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -693,5 +693,378 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count.0, 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_removed_directories_removes_tracks_under_removed_dir() {
+        let (dir, pool) = create_test_pool("cleanup-removed-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let dir_path = dir.utf8_path().canonicalize_utf8().unwrap();
+        let path1 = dir_path.join("track1.flac");
+        let path2 = dir_path.join("track2.flac");
+        std::fs::write(&path1, b"").unwrap();
+        std::fs::write(&path2, b"").unwrap();
+
+        let meta1 = track_metadata("Album", "Artist", "Track 1", 1);
+        let meta2 = track_metadata("Album", "Artist", "Track 2", 2);
+        insert_metadata(&mut conn, &meta1, &path1).await.unwrap();
+        insert_metadata(&mut conn, &meta2, &path2).await.unwrap();
+        drop(conn);
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.directories = vec![dir_path];
+        scan_record.records.insert(path1.clone(), UNIX_EPOCH);
+        scan_record.records.insert(path2.clone(), UNIX_EPOCH);
+
+        let updated = cleanup_removed_directories(&pool, &mut scan_record, &[]).await;
+        assert!(updated.is_empty());
+        assert!(!scan_record.records.contains_key(&path1));
+        assert!(!scan_record.records.contains_key(&path2));
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM track")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_removed_directories_preserves_tracks_in_remaining_dirs() {
+        let (dir, pool) = create_test_pool("cleanup-removed-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let dir_path = dir.utf8_path().canonicalize_utf8().unwrap();
+        let path_a = dir_path.join("track_a.flac");
+        // Use a subdirectory to simulate dirB being a separate tree
+        let sub = dir_path.join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        let path_b = sub.join("track_b.flac");
+
+        std::fs::write(&path_a, b"").unwrap();
+        std::fs::write(&path_b, b"").unwrap();
+
+        let meta1 = track_metadata("Album A", "Artist", "Track A", 1);
+        let meta2 = track_metadata("Album B", "Artist", "Track B", 1);
+        insert_metadata(&mut conn, &meta1, &path_a).await.unwrap();
+        insert_metadata(&mut conn, &meta2, &path_b).await.unwrap();
+        drop(conn);
+
+        // Both dir_path and sub are in old set; only dir_path remains
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.directories = vec![dir_path.clone(), sub.clone()];
+        scan_record.records.insert(path_a.clone(), UNIX_EPOCH);
+        scan_record.records.insert(path_b.clone(), UNIX_EPOCH);
+
+        let updated = cleanup_removed_directories(&pool, &mut scan_record, &[dir_path]).await;
+        assert!(updated.is_empty());
+        // track_a (under dir_path) should remain
+        assert!(scan_record.records.contains_key(&path_a));
+        // track_b (under sub, which was removed) should be gone
+        assert!(!scan_record.records.contains_key(&path_b));
+
+        let count_a: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM track WHERE location = $1")
+            .bind(path_a.as_str())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count_a.0, 1);
+
+        let count_b: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM track WHERE location = $1")
+            .bind(path_b.as_str())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count_b.0, 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_removed_directories_returns_empty_when_no_dirs_removed() {
+        let (dir, pool) = create_test_pool("cleanup-removed-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let path = dir.utf8_join("track.flac");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+        drop(conn);
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.directories = vec![dir.utf8_path()];
+        scan_record.records.insert(path, UNIX_EPOCH);
+
+        let updated =
+            cleanup_removed_directories(&pool, &mut scan_record, &[dir.utf8_path()]).await;
+        assert!(updated.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_removed_directories_returns_affected_playlist_ids() {
+        let (dir, pool) = create_test_pool("cleanup-removed-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let dir_path = dir.utf8_path().canonicalize_utf8().unwrap();
+        let path = dir_path.join("track.flac");
+        std::fs::write(&path, b"").unwrap();
+
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+        drop(conn);
+
+        let playlist_id = add_track_to_playlist(&pool, &path, "Test Playlist").await;
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.directories = vec![dir_path];
+        scan_record.records.insert(path, UNIX_EPOCH);
+
+        let updated = cleanup_removed_directories(&pool, &mut scan_record, &[]).await;
+        assert!(updated.contains(&playlist_id));
+
+        let pi_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM playlist_item")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(pi_count.0, 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_exclusions_removes_multiple_missing_files() {
+        let (dir, pool) = create_test_pool("cleanup-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let path1 = dir.utf8_join("track1.flac");
+        let path2 = dir.utf8_join("track2.flac");
+        let path3 = dir.utf8_join("track3.flac");
+        std::fs::write(dir.join("track1.flac"), b"").unwrap();
+        std::fs::write(dir.join("track2.flac"), b"").unwrap();
+        std::fs::write(dir.join("track3.flac"), b"").unwrap();
+
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path1).await.unwrap();
+        insert_metadata(&mut conn, &meta, &path2).await.unwrap();
+        insert_metadata(&mut conn, &meta, &path3).await.unwrap();
+        drop(conn);
+
+        std::fs::remove_file(dir.join("track1.flac")).unwrap();
+        std::fs::remove_file(dir.join("track2.flac")).unwrap();
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.records.insert(path1.clone(), UNIX_EPOCH);
+        scan_record.records.insert(path2.clone(), UNIX_EPOCH);
+        scan_record.records.insert(path3.clone(), UNIX_EPOCH);
+
+        let updated = cleanup_with_exclusions(&pool, &mut scan_record, &[]).await;
+        assert!(updated.is_empty());
+        assert!(!scan_record.records.contains_key(&path1));
+        assert!(!scan_record.records.contains_key(&path2));
+        assert!(scan_record.records.contains_key(&path3));
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM track")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_exclusions_preserves_files_still_on_disk() {
+        let (dir, pool) = create_test_pool("cleanup-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let path1 = dir.utf8_join("track1.flac");
+        let path2 = dir.utf8_join("track2.flac");
+        std::fs::write(dir.join("track1.flac"), b"").unwrap();
+        std::fs::write(dir.join("track2.flac"), b"").unwrap();
+
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path1).await.unwrap();
+        insert_metadata(&mut conn, &meta, &path2).await.unwrap();
+        drop(conn);
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.records.insert(path1.clone(), UNIX_EPOCH);
+        scan_record.records.insert(path2.clone(), UNIX_EPOCH);
+
+        let updated = cleanup_with_exclusions(&pool, &mut scan_record, &[]).await;
+        assert!(updated.is_empty());
+        assert!(scan_record.records.contains_key(&path1));
+        assert!(scan_record.records.contains_key(&path2));
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM track")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 2);
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_exclusions_removes_lyrics_for_deleted_tracks() {
+        let (dir, pool) = create_test_pool("cleanup-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let path = dir.utf8_join("track.flac");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+
+        let mut meta = track_metadata("Album", "Artist", "Track", 1);
+        meta.lyrics = Some("test lyrics".to_string());
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+        drop(conn);
+
+        assert_eq!(count_rows(&pool, "lyrics").await, 1);
+
+        std::fs::remove_file(dir.join("track.flac")).unwrap();
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.records.insert(path, UNIX_EPOCH);
+
+        cleanup_with_exclusions(&pool, &mut scan_record, &[]).await;
+        assert_eq!(count_rows(&pool, "lyrics").await, 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_exclusions_returns_affected_playlist_ids() {
+        let (dir, pool) = create_test_pool("cleanup-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let path = dir.utf8_join("track.flac");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+        drop(conn);
+
+        let playlist_id = add_track_to_playlist(&pool, &path, "Test Playlist").await;
+
+        std::fs::remove_file(dir.join("track.flac")).unwrap();
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.records.insert(path, UNIX_EPOCH);
+
+        let updated = cleanup_with_exclusions(&pool, &mut scan_record, &[]).await;
+        assert!(updated.contains(&playlist_id));
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_exclusions_cascades_album_and_artist_deletion() {
+        let (dir, pool) = create_test_pool("cleanup-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let path = dir.utf8_join("track.flac");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+        drop(conn);
+
+        assert_eq!(count_rows(&pool, "album").await, 1);
+        assert_eq!(count_rows(&pool, "artist").await, 1);
+
+        std::fs::remove_file(dir.join("track.flac")).unwrap();
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.records.insert(path, UNIX_EPOCH);
+
+        cleanup_with_exclusions(&pool, &mut scan_record, &[]).await;
+
+        assert_eq!(count_rows(&pool, "album").await, 0);
+        assert_eq!(count_rows(&pool, "artist").await, 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_exclusions_keeps_album_when_other_tracks_remain() {
+        let (dir, pool) = create_test_pool("cleanup-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let path1 = dir.utf8_join("track1.flac");
+        let path2 = dir.utf8_join("track2.flac");
+        std::fs::write(dir.join("track1.flac"), b"").unwrap();
+        std::fs::write(dir.join("track2.flac"), b"").unwrap();
+
+        let meta1 = track_metadata("Album", "Artist", "Track 1", 1);
+        let meta2 = track_metadata("Album", "Artist", "Track 2", 2);
+        insert_metadata(&mut conn, &meta1, &path1).await.unwrap();
+        insert_metadata(&mut conn, &meta2, &path2).await.unwrap();
+        drop(conn);
+
+        assert_eq!(count_rows(&pool, "album").await, 1);
+        assert_eq!(count_rows(&pool, "artist").await, 1);
+
+        std::fs::remove_file(dir.join("track1.flac")).unwrap();
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.records.insert(path1, UNIX_EPOCH);
+        scan_record.records.insert(path2, UNIX_EPOCH);
+
+        cleanup_with_exclusions(&pool, &mut scan_record, &[]).await;
+
+        assert_eq!(count_rows(&pool, "album").await, 1);
+        assert_eq!(count_rows(&pool, "artist").await, 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_exclusions_handles_moved_file() {
+        let (dir, pool) = create_test_pool("cleanup-move-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        // Insert a track at old path with lyrics
+        let old_path = dir.utf8_join("track.flac");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+        let mut meta = track_metadata("Album", "Artist", "Old Track", 1);
+        meta.lyrics = Some("old lyrics".to_string());
+        insert_metadata(&mut conn, &meta, &old_path).await.unwrap();
+
+        // Add to playlist
+        let playlist_id = add_track_to_playlist(&pool, &old_path, "Test Playlist").await;
+
+        // Delete old file (simulating move: old path no longer exists)
+        std::fs::remove_file(dir.join("track.flac")).unwrap();
+
+        // Create new file at a different path (the file after the move)
+        let new_path = dir.utf8_join("moved.flac");
+        std::fs::write(dir.join("moved.flac"), b"").unwrap();
+        let mut new_meta = track_metadata("Album", "Artist", "Moved Track", 1);
+        new_meta.lyrics = Some("moved lyrics".to_string());
+        insert_metadata(&mut conn, &new_meta, &new_path)
+            .await
+            .unwrap();
+        drop(conn);
+
+        // Set up scan_record with both paths
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.records.insert(old_path.clone(), UNIX_EPOCH);
+        scan_record.records.insert(new_path.clone(), UNIX_EPOCH);
+
+        let updated = cleanup_with_exclusions(&pool, &mut scan_record, &[]).await;
+
+        // Old track should be gone from records and DB
+        assert!(!scan_record.records.contains_key(&old_path));
+        let old_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM track WHERE location = $1")
+            .bind(old_path.as_str())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(old_count.0, 0);
+
+        // New track should remain
+        assert!(scan_record.records.contains_key(&new_path));
+        let new_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM track WHERE location = $1")
+            .bind(new_path.as_str())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(new_count.0, 1);
+
+        // Old lyrics should be cleaned up (only 1 set remains, for the new track)
+        assert_eq!(count_rows(&pool, "lyrics").await, 1);
+
+        // Playlist items for old track should be cleaned up
+        let pi_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM playlist_item")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(pi_count.0, 0);
+
+        // Updated should contain the playlist id from the removed track
+        assert!(updated.contains(&playlist_id));
     }
 }

--- a/src/library/scan/discover.rs
+++ b/src/library/scan/discover.rs
@@ -450,3 +450,248 @@ pub fn discover(
 
     discovered_total
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        settings::scan::MissingFolderPolicy,
+        test_support::{
+            TestDir, create_test_pool, insert_metadata, register_test_media_providers,
+            track_metadata,
+        },
+    };
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use tokio::sync::mpsc;
+
+    fn scan_settings(root: Utf8PathBuf) -> ScanSettings {
+        ScanSettings {
+            paths: vec![root],
+            missing_folder_policy: MissingFolderPolicy::default(),
+        }
+    }
+
+    #[test]
+    fn sidecar_lyrics_path_returns_lrc_next_to_track() {
+        let path = Utf8PathBuf::from("/music/album/song.flac");
+        assert_eq!(
+            sidecar_lyrics_path(&path),
+            Some(Utf8PathBuf::from("/music/album/song.lrc"))
+        );
+    }
+
+    #[test]
+    fn sidecar_lyrics_path_returns_none_without_stem() {
+        let path = Utf8PathBuf::from("/");
+        assert_eq!(sidecar_lyrics_path(&path), None);
+    }
+
+    #[test]
+    fn discover_emits_supported_files_recursively() {
+        register_test_media_providers();
+        let dir = TestDir::new("discover-test");
+        let sub = dir.join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(dir.join("track1.flac"), b"").unwrap();
+        std::fs::write(dir.join("readme.txt"), b"").unwrap();
+        std::fs::write(sub.join("track2.mp3"), b"").unwrap();
+
+        let settings = scan_settings(dir.utf8_path());
+        let scan_record = Arc::new(Mutex::new(ScanRecord::new_current()));
+        let (path_tx, mut path_rx) = mpsc::channel::<(Utf8PathBuf, SystemTime)>(100);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let count = discover(settings, scan_record, path_tx, cancel);
+
+        let mut paths = Vec::new();
+        while let Some((path, _)) = path_rx.blocking_recv() {
+            paths.push(path);
+        }
+
+        assert_eq!(count, 2);
+        assert_eq!(paths.len(), 2);
+        let names: Vec<_> = paths
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string())
+            .collect();
+        assert!(names.contains(&"track1.flac".to_string()));
+        assert!(names.contains(&"track2.mp3".to_string()));
+    }
+
+    #[test]
+    fn discover_skips_unchanged_recorded_files() {
+        register_test_media_providers();
+        let dir = TestDir::new("discover-test");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+        let path = dir.utf8_join("track.flac").canonicalize_utf8().unwrap();
+        let ts = file_scan_timestamp(&path).unwrap();
+
+        let mut record = ScanRecord::new_current();
+        record.records.insert(path, ts);
+
+        let settings = scan_settings(dir.utf8_path().canonicalize_utf8().unwrap());
+        let scan_record = Arc::new(Mutex::new(record));
+        let (path_tx, mut path_rx) = mpsc::channel::<(Utf8PathBuf, SystemTime)>(10);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let count = discover(settings, scan_record, path_tx, cancel);
+        assert_eq!(count, 0);
+        assert!(path_rx.blocking_recv().is_none());
+    }
+
+    #[test]
+    fn discover_emits_file_when_timestamp_differs() {
+        register_test_media_providers();
+        let dir = TestDir::new("discover-test");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+        let path = dir.utf8_join("track.flac").canonicalize_utf8().unwrap();
+
+        let mut record = ScanRecord::new_current();
+        record
+            .records
+            .insert(path.clone(), UNIX_EPOCH + Duration::from_secs(1));
+
+        let settings = scan_settings(dir.utf8_path().canonicalize_utf8().unwrap());
+        let scan_record = Arc::new(Mutex::new(record));
+        let (path_tx, mut path_rx) = mpsc::channel::<(Utf8PathBuf, SystemTime)>(10);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let count = discover(settings, scan_record, path_tx, cancel);
+        assert_eq!(count, 1);
+        let emitted = path_rx.blocking_recv().unwrap();
+        assert_eq!(emitted.0, path);
+    }
+
+    #[test]
+    fn discover_emits_file_when_sidecar_lyrics_changes() {
+        register_test_media_providers();
+        let dir = TestDir::new("discover-test");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+        let path = dir.utf8_join("track.flac").canonicalize_utf8().unwrap();
+        let old_ts = file_scan_timestamp(&path).unwrap();
+
+        std::fs::write(dir.join("track.lrc"), "[00:00.00] lyrics").unwrap();
+
+        let mut record = ScanRecord::new_current();
+        record.records.insert(path.clone(), old_ts);
+
+        let settings = scan_settings(dir.utf8_path().canonicalize_utf8().unwrap());
+        let scan_record = Arc::new(Mutex::new(record));
+        let (path_tx, mut path_rx) = mpsc::channel::<(Utf8PathBuf, SystemTime)>(10);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let count = discover(settings, scan_record, path_tx, cancel);
+        assert_eq!(count, 1);
+        let emitted = path_rx.blocking_recv().unwrap();
+        assert_eq!(emitted.0, path);
+    }
+
+    #[test]
+    fn rescan_discover_deduplicates_paths() {
+        register_test_media_providers();
+        let dir = TestDir::new("rescan-test");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+
+        let path = dir.utf8_join("track.flac").canonicalize_utf8().unwrap();
+        let dir_path = dir.utf8_path().canonicalize_utf8().unwrap();
+        let (path_tx, mut path_rx) = mpsc::channel::<(Utf8PathBuf, SystemTime)>(10);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let count = rescan_discover(vec![path.clone(), dir_path], path_tx, cancel);
+        assert_eq!(count, 1);
+        let emitted = path_rx.blocking_recv().unwrap();
+        assert_eq!(emitted.0, path);
+        assert!(path_rx.blocking_recv().is_none());
+    }
+
+    #[test]
+    fn rescan_discover_expands_directories_one_level_only() {
+        register_test_media_providers();
+        let dir = TestDir::new("rescan-test");
+        std::fs::write(dir.join("top.flac"), b"").unwrap();
+        let nested = dir.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("deep.flac"), b"").unwrap();
+
+        let dir_path = dir.utf8_path().canonicalize_utf8().unwrap();
+        let (path_tx, mut path_rx) = mpsc::channel::<(Utf8PathBuf, SystemTime)>(10);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let count = rescan_discover(vec![dir_path], path_tx, cancel);
+        assert_eq!(count, 1);
+        let emitted = path_rx.blocking_recv().unwrap();
+        assert_eq!(emitted.0.file_name().unwrap(), "top.flac");
+    }
+
+    #[test]
+    fn rescan_discover_ignores_scan_record_state() {
+        register_test_media_providers();
+        let dir = TestDir::new("rescan-test");
+        std::fs::write(dir.join("track.flac"), b"").unwrap();
+
+        let path = dir.utf8_join("track.flac").canonicalize_utf8().unwrap();
+        let (path_tx, mut path_rx) = mpsc::channel::<(Utf8PathBuf, SystemTime)>(10);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let count = rescan_discover(vec![path.clone()], path_tx, cancel);
+        assert_eq!(count, 1);
+        assert_eq!(path_rx.blocking_recv().unwrap().0, path);
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_exclusions_removes_missing_tracks() {
+        let (dir, pool) = create_test_pool("cleanup-test").await;
+        let file = dir.join("track.flac");
+        std::fs::write(&file, b"").unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
+        let path = dir.utf8_join("track.flac");
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+
+        std::fs::remove_file(&file).unwrap();
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.records.insert(path.clone(), UNIX_EPOCH);
+
+        let updated = cleanup_with_exclusions(&pool, &mut scan_record, &[]).await;
+        assert!(updated.is_empty());
+        assert!(!scan_record.records.contains_key(&path));
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM track WHERE location = $1")
+            .bind(path.as_str())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_exclusions_keeps_missing_tracks_under_excluded_roots() {
+        let (dir, pool) = create_test_pool("cleanup-test").await;
+        let file = dir.join("track.flac");
+        std::fs::write(&file, b"").unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
+        let path = dir.utf8_join("track.flac").canonicalize_utf8().unwrap();
+        let meta = track_metadata("Album", "Artist", "Track", 1);
+        insert_metadata(&mut conn, &meta, &path).await.unwrap();
+
+        std::fs::remove_file(&file).unwrap();
+
+        let mut scan_record = ScanRecord::new_current();
+        scan_record.records.insert(path.clone(), UNIX_EPOCH);
+
+        let root = dir.utf8_path().canonicalize_utf8().unwrap();
+        let updated = cleanup_with_exclusions(&pool, &mut scan_record, &[root]).await;
+        assert!(updated.is_empty());
+        assert!(scan_record.records.contains_key(&path));
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM track WHERE location = $1")
+            .bind(path.as_str())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 1);
+    }
+}

--- a/src/library/scan/record.rs
+++ b/src/library/scan/record.rs
@@ -175,3 +175,72 @@ pub async fn write_scan_record(scan_record: &ScanRecord, path: &Path) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestDir;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    #[tokio::test]
+    async fn missing_record_returns_current() {
+        let dir = TestDir::new("scan-record-test");
+        let record = load_scan_record(&dir.join("missing.hsr")).await;
+        assert!(!record.is_version_mismatch());
+        assert!(record.records.is_empty());
+        assert!(record.directories.is_empty());
+    }
+
+    #[tokio::test]
+    async fn corrupt_record_returns_current() {
+        let dir = TestDir::new("scan-record-test");
+        let path = dir.join("corrupt.hsr");
+        std::fs::write(&path, b"not valid postcard data").unwrap();
+        let record = load_scan_record(&path).await;
+        assert!(!record.is_version_mismatch());
+        assert!(record.records.is_empty());
+    }
+
+    #[tokio::test]
+    async fn write_and_load_roundtrip() {
+        let dir = TestDir::new("scan-record-test");
+        let path = dir.join("record.hsr");
+        let mut record = ScanRecord::new_current();
+        let t1 = UNIX_EPOCH + Duration::from_secs(1_234_567_890);
+        let p1 = Utf8PathBuf::from("/music/track.flac");
+        record.records.insert(p1.clone(), t1);
+        record.directories.push(Utf8PathBuf::from("/music"));
+
+        write_scan_record(&record, &path).await;
+        let loaded = load_scan_record(&path).await;
+
+        assert_eq!(loaded.version, SCAN_VERSION);
+        assert_eq!(loaded.records.get(&p1), Some(&t1));
+        assert_eq!(loaded.directories, vec![Utf8PathBuf::from("/music")]);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_writes_loadable_record() {
+        let dir = TestDir::new("scan-record-test");
+        let path = dir.join("checkpoint.hsr");
+        let mut checkpoint = FxHashMap::default();
+        let t1 = UNIX_EPOCH + Duration::from_secs(1_000);
+        let p1 = Utf8PathBuf::from("/music/a.flac");
+        checkpoint.insert(p1.clone(), t1);
+
+        let guard = Arc::new(Mutex::new(checkpoint));
+        write_checkpoint(guard, vec![Utf8PathBuf::from("/music")], &path).await;
+
+        let loaded = load_scan_record(&path).await;
+        assert_eq!(loaded.version, SCAN_VERSION);
+        assert_eq!(loaded.records.get(&p1), Some(&t1));
+        assert_eq!(loaded.directories, vec![Utf8PathBuf::from("/music")]);
+    }
+
+    #[test]
+    fn version_mismatch_detected() {
+        let mut record = ScanRecord::new_current();
+        record.version = 1;
+        assert!(record.is_version_mismatch());
+    }
+}

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,7 +1,23 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        Once,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use rustc_hash::{FxHashMap, FxHashSet};
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::{
+    library::{db, scan::database::update_metadata},
+    media::{
+        builtin::{lofty, symphonia},
+        lookup_table,
+        metadata::Metadata,
+    },
 };
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(0);
@@ -25,10 +41,74 @@ impl TestDir {
     pub(crate) fn join(&self, name: &str) -> PathBuf {
         self.path.join(name)
     }
+
+    pub(crate) fn utf8_path(&self) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(self.path.clone()).unwrap()
+    }
+
+    pub(crate) fn utf8_join(&self, name: &str) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(self.path.join(name)).unwrap()
+    }
 }
 
 impl Drop for TestDir {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.path);
     }
+}
+
+/// Registers the built-in media providers exactly once per test process.
+///
+/// Must NOT be called from inside a `#[tokio::test]` — `add_provider` uses
+/// `blocking_write` on a tokio `RwLock`, which panics inside a runtime.
+pub(crate) fn register_test_media_providers() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        lookup_table::add_provider(Box::new(lofty::LoftyProvider));
+        lookup_table::add_provider(Box::new(symphonia::SymphoniaProvider));
+    });
+}
+
+pub(crate) async fn create_test_pool(prefix: &str) -> (TestDir, SqlitePool) {
+    let dir = TestDir::new(prefix);
+    let pool = db::create_pool(dir.join("library.db")).await.unwrap();
+    (dir, pool)
+}
+
+pub(crate) fn track_metadata(album: &str, artist: &str, title: &str, track: u64) -> Metadata {
+    Metadata {
+        name: Some(title.to_string()),
+        artist: Some(artist.to_string()),
+        album_artist: Some(artist.to_string()),
+        album: Some(album.to_string()),
+        track_current: Some(track),
+        disc_current: Some(1),
+        ..Metadata::default()
+    }
+}
+
+pub(crate) async fn insert_metadata(
+    conn: &mut SqliteConnection,
+    metadata: &Metadata,
+    path: &Utf8Path,
+) -> anyhow::Result<()> {
+    update_metadata(
+        conn,
+        metadata,
+        path,
+        100,
+        &None,
+        false,
+        &mut FxHashSet::default(),
+        &mut FxHashMap::default(),
+        &mut FxHashMap::default(),
+        &mut FxHashMap::default(),
+    )
+    .await
+}
+
+pub(crate) async fn count_rows(pool: &SqlitePool, table: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) FROM {table}");
+    let row: (i64,) = sqlx::query_as(&sql).fetch_one(pool).await.unwrap();
+    row.0
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -107,6 +107,23 @@ pub(crate) async fn insert_metadata(
     .await
 }
 
+pub(crate) async fn add_track_to_playlist(
+    pool: &SqlitePool,
+    track_path: &Utf8Path,
+    playlist_name: &str,
+) -> i64 {
+    let playlist_id = db::create_playlist(pool, playlist_name).await.unwrap();
+    let (track_id,): (i64,) = sqlx::query_as("SELECT id FROM track WHERE location = $1")
+        .bind(track_path.as_str())
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    db::add_playlist_item(pool, playlist_id, track_id)
+        .await
+        .unwrap();
+    playlist_id
+}
+
 pub(crate) async fn count_rows(pool: &SqlitePool, table: &str) -> i64 {
     let sql = format!("SELECT COUNT(*) FROM {table}");
     let row: (i64,) = sqlx::query_as(&sql).fetch_one(pool).await.unwrap();


### PR DESCRIPTION
## Summary
Adds more library scan/metadata tests, which have been sorely needed for a while. Closes #336.

## Changes
<!-- What specific changes were made? -->

## Testing
<!-- How did you test these changes? -->

## Checklist
- [x] No new warnings or clippy lints introduced - if so, explain why
- [ ] Code works on all supported platforms (Linux, macOS, Windows) - tested on available platforms
- [ ] Documentation added/updated where needed
- [x] If using generative AI assistance, disclosure is provided (co-authored-by tag or PR description) - see [here](CONTRIBUTING.md) - K2.6 was used to generate some of these tests.
